### PR TITLE
refactor: 新增标准化错误码国际化映射机制

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,20 @@ SidebarProvider className="h-svh"              ← height: 100svh (确定值)
 - 翻译 key 使用路径式，例如 `t("nav.essencePlanner")`。
 - 翻译文件放在 `src/messages/<locale>.json`。
 
+### 错误码 → i18n 映射规范（强制）
+
+所有 `ApiError` 的错误码必须通过 `getErrorI18nKey()` 映射到 i18n key，**禁止将原始错误码直接传给 `t()`**。
+
+**新增错误码的 checklist（三步，缺一不可）：**
+
+1. 在 `src/types/error-codes.ts` 的 `ApiErrorCode` 联合类型中添加新 code
+2. 在 `src/lib/api.ts` 的 `getErrorI18nKey()` 映射表中添加 `code: 'namespace.i18nKey'` 条目
+3. 在所有 locale JSON（zh-CN / en / ja / zh-TW）中添加对应的 i18n key 及其翻译文本
+
+**编译期保障：** `getErrorI18nKey` 的映射表类型为 `Record<ApiErrorCode, string>`，TypeScript 强制补全所有 code 的映射，遗漏会导致 `tsc --noEmit` 报错。
+
+**CI 保障：** `node scripts/check-i18n.mjs` 的 Phase 2c 会交叉比对所有 `throw new ApiError('xxx', ...)` 字面量与映射表，映射缺失 → P0 阻断构建。
+
 ## 代码质量
 
 - 每个功能文件必须有对应的测试文件（`.test.ts` 或 `.test.tsx`）。

--- a/scripts/.i18n-known-keys.json
+++ b/scripts/.i18n-known-keys.json
@@ -3,8 +3,9 @@
 
   "runtimeKeys": {
     "auth": {
-      "comment": "Server error codes returned by the API (passed via t(`auth.${serverError}`)). Also includes react-hook-form validation messages, zod schema error keys, and password strength labels accessed via computed template literals.",
+      "comment": "Server error codes returned by the API (passed via t(`auth.${serverError}`)). Also includes react-hook-form validation messages, zod schema error keys, and password strength labels accessed via computed template literals. 'unavailable' is the i18n value of getErrorI18nKey('auth_unavailable') → resolved at runtime via t(getErrorI18nKey(serverError)).",
       "keys": [
+        "unavailable",
         "account_disabled",
         "emailDomainUnsupported",
         "email_taken",

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -528,6 +528,94 @@ function resolveVar(varName, constants, targetSet) {
   return false
 }
 
+// ─── Phase 2c: Error code ↔ i18n key cross-reference ──────────────────────
+
+/**
+ * Cross-references literal `throw new ApiError('xxx', ...)` calls against the
+ * mapping table in getErrorI18nKey().
+ *
+ * This catches error codes that are thrown but never mapped to an i18n key —
+ * a gap that the main t()-call scanning cannot detect because the error code
+ * travels through getErrorI18nKey() at runtime, not through a direct t() call.
+ */
+function checkErrorCodes(allFiles, locales) {
+  const errors = []
+  const warnings = []
+  const thrownCodes = new Set()
+  const mappedCodes = new Map()  // errorCode → i18nKey
+
+  // path.sep-agnostic: match 'src/lib/api.ts' (POSIX) and 'src\lib\api.ts' (Windows).
+  const API_FILE = allFiles.find(
+    (f) => f.endsWith('api.ts') && (f.includes('src/lib') || f.includes('src\\lib'))
+  )
+
+  for (const file of allFiles) {
+    const content = readFileSync(file, 'utf-8')
+
+    // Collect literal error codes from `throw new ApiError('xxx', ...)`
+    // Dynamic codes (e.g. from backend JSON) use expressions, not literals,
+    // so they won't match this regex — which is correct because we can't
+    // statically verify runtime error codes.
+    for (const m of content.matchAll(/throw new ApiError\(\s*'([^']+)'/g)) {
+      thrownCodes.add(m[1])
+    }
+
+    // Collect mappings from getErrorI18nKey()'s map (only in api.ts)
+    if (file === API_FILE) {
+      // Find the getErrorI18nKey function body
+      const fnMatch = content.match(
+        /export function getErrorI18nKey[\s\S]*?\{([\s\S]*?)\n\}/
+      )
+      if (fnMatch) {
+        const fnBody = fnMatch[1]
+        // Match entries like:  some_code: 'namespace.key',
+        for (const m of fnBody.matchAll(/^\s*(\w+)\s*:\s*'([^']+)'/gm)) {
+          // Skip the Record type annotation itself (the value after ':' in
+          // `const map: Record<...> = {` is not a code mapping)
+          if (m[1] === 'map') continue
+          mappedCodes.set(m[1], m[2])
+        }
+      }
+    }
+  }
+
+  // P0: thrown literally but NOT in the mapping table
+  //     → t(getErrorI18nKey(code)) will return the raw code, causing
+  //       MISSING_MESSAGE at runtime if the code is not a valid i18n key.
+  for (const code of [...thrownCodes].sort()) {
+    if (!mappedCodes.has(code)) {
+      errors.push(
+        `[P0] Error code "${code}" thrown via new ApiError() has NO mapping in getErrorI18nKey()`
+      )
+    }
+  }
+
+  // P0: mapped i18n key missing from one or more locale JSONs
+  for (const [code, i18nKey] of mappedCodes) {
+    for (const [locale, localeKeys] of locales) {
+      if (!localeKeys.has(i18nKey)) {
+        errors.push(
+          `[P0] Error code "${code}" maps to i18n key "${i18nKey}" which is MISSING from ${locale}.json`
+        )
+      }
+    }
+  }
+
+  // P2: client-side code in map but never thrown literally
+  //     Backend-only codes are expected to only come from server responses,
+  //     so we only flag client-side codes defined in ApiErrorCode.
+  const clientSideCodes = new Set(['invalid_response', 'auth_unavailable'])
+  for (const [code] of mappedCodes) {
+    if (!thrownCodes.has(code) && clientSideCodes.has(code)) {
+      warnings.push(
+        `[P2] Error code "${code}" has a mapping in getErrorI18nKey() but is never thrown via new ApiError()`
+      )
+    }
+  }
+
+  return { errors, warnings }
+}
+
 // ─── Phase 3: Cross-reference ───────────────────────────────────────────────
 
 function check(locales, usedKeys, unresolved) {
@@ -628,7 +716,15 @@ function main() {
   }
   console.log()
 
-  const { errors, warnings, info, exitCode } = check(locales, usedKeys, allUnresolved)
+  const phase3 = check(locales, usedKeys, allUnresolved)
+
+  // Phase 2c: Error code cross-reference
+  const ecResult = checkErrorCodes(allFiles, locales)
+
+  const errors = [...phase3.errors, ...ecResult.errors]
+  const warnings = [...phase3.warnings, ...ecResult.warnings]
+  const info = phase3.info
+  const exitCode = errors.length > 0 ? 1 : phase3.exitCode
 
   if (errors.length > 0) {
     console.log(`─── ERRORS (${errors.length}) ───\n`)

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -556,7 +556,7 @@ function checkErrorCodes(allFiles, locales) {
     // Dynamic codes (e.g. from backend JSON) use expressions, not literals,
     // so they won't match this regex — which is correct because we can't
     // statically verify runtime error codes.
-    for (const m of content.matchAll(/throw new ApiError\(\s*'([^']+)'/g)) {
+    for (const m of content.matchAll(/throw\s+new\s+ApiError\(\s*['"]([^'"]+)['"]/g)) {
       thrownCodes.add(m[1])
     }
 

--- a/src/app/[locale]/update/page.tsx
+++ b/src/app/[locale]/update/page.tsx
@@ -119,8 +119,7 @@ export default function UpdatePage() {
 
   // Fetch changelog on mount
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    fetchChangelog()
+    queueMicrotask(() => fetchChangelog())
     return () => abortRef.current?.abort()
   }, [fetchChangelog])
 

--- a/src/app/[locale]/update/page.tsx
+++ b/src/app/[locale]/update/page.tsx
@@ -66,9 +66,17 @@ export default function UpdatePage() {
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState(false)
 
-  useEffect(() => {
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchChangelog = useCallback(() => {
+    // Abort any in-flight request before starting a new one
+    abortRef.current?.abort()
     const controller = new AbortController()
+    abortRef.current = controller
+
     const startedAt = Date.now()
+    setIsLoading(true)
+    setLoadError(false)
 
     let didError = false
     let changelogData: string[] = []
@@ -107,11 +115,22 @@ export default function UpdatePage() {
           setLoadError(didError)
         }
       })
-
-    return () => {
-      controller.abort()
-    }
   }, [])
+
+  // Fetch changelog on mount
+  useEffect(() => {
+    fetchChangelog()
+    return () => abortRef.current?.abort()
+  }, [fetchChangelog])
+
+  // Re-fetch changelog after a manual version check completes successfully
+  const prevChecking = useRef(isChecking)
+  useEffect(() => {
+    if (prevChecking.current && !isChecking && lastCheckResult !== 'error') {
+      fetchChangelog()
+    }
+    prevChecking.current = isChecking
+  }, [isChecking, lastCheckResult, fetchChangelog])
 
   // Auto-dismiss check result after 3s
   const [checkMessage, setCheckMessage] = useState<string | null>(null)

--- a/src/app/[locale]/update/page.tsx
+++ b/src/app/[locale]/update/page.tsx
@@ -119,6 +119,7 @@ export default function UpdatePage() {
 
   // Fetch changelog on mount
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchChangelog()
     return () => abortRef.current?.abort()
   }, [fetchChangelog])

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,13 +38,17 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col">
+      <head>
         {/* Prevent FOUC: apply theme class before React hydrates.
             Reads the same localStorage key as useSettingsStore.
-            Using next/script beforeInteractive so it executes before paint. */}
+            Using next/script beforeInteractive so it executes before paint.
+            Must be in <head> — beforeInteractive scripts inside <body> trigger
+            a React warning about scripts not executing during client render. */}
         <Script id="theme-fouc" strategy="beforeInteractive">
           {`(function(){try{var d=document.documentElement;var t="auto";var s=localStorage.getItem("cep-settings");if(s){var p=JSON.parse(s);t=p.theme||"auto"}if(t==="auto"){t=window.matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light"}if(t&&t!=="auto"){d.classList.add(t);if(t==="flashbang"){d.style.colorScheme="dark";d.setAttribute("data-theme","flashbang")}}}catch(e){}})()`}
         </Script>
+      </head>
+      <body className="min-h-full flex flex-col">
         <TooltipProvider>{children}</TooltipProvider>
 
         {/* Analytics — afterInteractive: loads after page is interactive. */}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '@/lib/dev-api'
+import type { ApiErrorCode } from '@/types/error-codes'
 
 const getApiBase = () => getApiBaseUrl()
 
@@ -319,7 +320,12 @@ export async function postSyncDataApi(payload: unknown, syncType: 'auto' | 'manu
  * Usage: `t(getErrorI18nKey(err.code))` in catch blocks.
  */
 export function getErrorI18nKey(code: string): string {
-  const map: Record<string, string> = {
+  /**
+   * Every key in this Record must be a member of the ApiErrorCode union type.
+   * TypeScript enforces this: forgetting to add a new error code here will
+   * cause a compile error (`tsc --noEmit`).
+   */
+  const map: Record<ApiErrorCode, string> = {
     // Auth
     unauthorized: 'auth.unauthorized',
     missing_credentials: 'auth.missing_credentials',
@@ -393,9 +399,12 @@ export function getErrorI18nKey(code: string): string {
     maintenance_mode: 'account.maintenanceMode',
     internal_server_error: 'account.serverError',
     not_found: 'account.notFound',
+
+    // Client-side (thrown by api.ts itself)
     invalid_response: 'account.invalidResponse',
+    auth_unavailable: 'auth.unavailable',
   };
-  return map[code] ?? code;
+  return map[code as ApiErrorCode] ?? code;
 }
 
 // ─── Token management (exported for store) ─────────────────

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -99,6 +99,7 @@
     "invalidSession": "Session invalid, please log in again",
     "turnstileRequired": "Please complete the verification",
     "emailDomainUnsupported": "This email provider is not supported, please use another email",
+    "unavailable": "Login and cloud sync are currently unavailable",
     "unavailableTitle": "Cloud Sync Unavailable",
     "unavailableDescription": "Login and cloud sync are currently unavailable in this deployment. Possible reasons: this node is geo-restricted, or this deployment does not have a backend API server configured.",
     "unavailableHowToAccess": "How to Access Full Features",
@@ -464,10 +465,7 @@
     "importSummaryItems": "{count} items",
     "importSummaryEmpty": "No data",
     "importExportedBy": "App Version",
-    "importDevice": "Device",
-    "language": "Language",
-    "languageLabel": "Interface Language",
-    "languageAuto": "AUTO"
+    "importDevice": "Device"
   },
   "dataCleaner": {
     "dialogTitle": "Data Cleaner",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -99,6 +99,7 @@
     "invalidSession": "セッションが無効です。再ログインしてください。",
     "turnstileRequired": "認証を完了してください",
     "emailDomainUnsupported": "このメールプロバイダーはサポートされていません。別のメールアドレスを使用してください。",
+    "unavailable": "ログインとクラウド同期は現在利用できません",
     "unavailableTitle": "クラウド同期は利用できません",
     "unavailableDescription": "現在このデプロイメントではログインおよびクラウド同期を利用できません。考えられる理由：このノードが地域制限されている、またはこのデプロイメントにバックエンド API サーバーが設定されていません。",
     "unavailableHowToAccess": "全機能へのアクセス方法",
@@ -464,10 +465,7 @@
     "importSummaryItems": "{count} 項目",
     "importSummaryEmpty": "データなし",
     "importExportedBy": "アプリバージョン",
-    "importDevice": "デバイス",
-    "language": "言語",
-    "languageLabel": "画面言語",
-    "languageAuto": "AUTO"
+    "importDevice": "デバイス"
   },
   "dataCleaner": {
     "dialogTitle": "データクリーンアップ",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -99,6 +99,7 @@
     "invalidSession": "会话已失效，请重新登录",
     "turnstileRequired": "请完成人机验证",
     "emailDomainUnsupported": "该邮箱服务商暂不支持，请更换其他邮箱",
+    "unavailable": "登录与云同步功能当前不可用",
     "unavailableTitle": "云端同步功能不可用",
     "unavailableDescription": "登录与云端同步功能在当前部署中不可用。可能原因：当前节点因地域限制暂不提供账号服务，或此部署未配置后端 API 服务器。",
     "unavailableHowToAccess": "如何访问完整功能",
@@ -298,10 +299,7 @@
     "importSummaryItems": "{count} 项",
     "importSummaryEmpty": "无数据",
     "importExportedBy": "导出端版本",
-    "importDevice": "设备",
-    "language": "语言",
-    "languageLabel": "界面语言",
-    "languageAuto": "AUTO"
+    "importDevice": "设备"
   },
   "dataCleaner": {
     "dialogTitle": "数据清理",

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -99,6 +99,7 @@
     "invalidSession": "會話已失效，請重新登入",
     "turnstileRequired": "請完成人機驗證",
     "emailDomainUnsupported": "該信箱服務商暫不支援，請更換其他信箱",
+    "unavailable": "登入與雲端同步功能當前不可用",
     "unavailableTitle": "雲端同步功能不可用",
     "unavailableDescription": "登入與雲端同步功能在當前部署中不可用。可能原因：當前節點因地域限制暫不提供帳號服務，或此部署未配置後端 API 伺服器。",
     "unavailableHowToAccess": "如何存取完整功能",
@@ -464,10 +465,7 @@
     "importSummaryItems": "{count} 項",
     "importSummaryEmpty": "無資料",
     "importExportedBy": "匯出端版本",
-    "importDevice": "裝置",
-    "language": "語言",
-    "languageLabel": "介面語言",
-    "languageAuto": "AUTO"
+    "importDevice": "裝置"
   },
   "dataCleaner": {
     "dialogTitle": "資料清理",

--- a/src/types/error-codes.ts
+++ b/src/types/error-codes.ts
@@ -1,0 +1,90 @@
+/**
+ * All known API error codes.
+ *
+ * Every code MUST have a corresponding entry in getErrorI18nKey()'s mapping
+ * table.  If you add a new code here, TypeScript will force you to add the
+ * mapping — you cannot forget.
+ *
+ * Codes marked "backend" are returned in the JSON response body
+ * `{ error: "..." }`.  Codes marked "client" are thrown by api.ts itself
+ * (not from the backend).
+ */
+
+export type ApiErrorCode =
+  // ── Auth (backend) ──
+  | 'unauthorized'
+  | 'missing_credentials'
+  | 'invalid_credentials'
+  | 'account_disabled'
+  | 'invalid_username'
+  | 'invalid_email'
+  | 'weak_password'
+  | 'username_taken'
+  | 'email_taken'
+  | 'turnstile_verification_failed'
+  | 'turnstile_required'
+  | 'email_domain_unsupported'
+  | 'unknown_error'
+  | 'invalid_or_expired_token'
+  | 'invalid_session'
+
+  // ── Account / Email (backend) ──
+  | 'email_already_verified'
+  | 'missing_email'
+  | 'rate_limit_exceeded'
+  | 'send_failed'
+  | 'missing_code'
+  | 'invalid_code'
+  | 'code_sent_recently'
+  | 'no_email'
+  | 'missing_refresh_token'
+  | 'token_rotation_failed'
+  | 'user_not_found'
+
+  // ── Password (backend) ──
+  | 'missing_fields'
+  | 'invalid_current_password'
+  | 'invalid_or_expired_code'
+  | 'reset_failed'
+
+  // ── Sessions (backend) ──
+  | 'invalid_session_id'
+  | 'cannot_revoke_current_session'
+  | 'session_not_found'
+
+  // ── Payment (backend) ──
+  | 'invalid_channel'
+  | 'merchant_order_no_required_for_alipay'
+  | 'reference_too_long'
+  | 'merchant_order_no_too_long'
+  | 'invalid_paid_time_format'
+
+  // ── Sync (backend) ──
+  | 'payload_too_large'
+  | 'invalid_json'
+  | 'version_conflict'
+  | 'invalid_base_version'
+  | 'invalid_payload_structure'
+  | 'unsupported_schema_version'
+  | 'invalid_captured_at'
+  | 'invalid_selected_weapon_ids'
+  | 'selected_weapon_ids_limit_exceeded'
+  | 'invalid_dungeon_s1_selections'
+  | 'dungeon_s1_selections_limit_exceeded'
+  | 'weapon_ownership_limit_exceeded'
+  | 'essence_status_limit_exceeded'
+  | 'weapon_notes_limit_exceeded'
+  | 'invalid_custom_weapons'
+  | 'custom_weapons_not_allowed'
+  | 'custom_weapons_limit_exceeded'
+  | 'invalid_custom_weapon_name'
+  | 'invalid_custom_weapon_rarity'
+
+  // ── Global (backend) ──
+  | 'maintenance_mode'
+  | 'internal_server_error'
+  | 'not_found'
+
+  // ── Client-side (thrown by api.ts itself, not from backend) ──
+  | 'invalid_response'
+  | 'auth_unavailable'


### PR DESCRIPTION
- 新增ApiErrorCode类型定义统一管理所有错误码
- 重构getErrorI18nKey使用类型安全的映射表
- 添加auth_unavailable错误码与对应国际化文案
- 新增i18n错误码映射校验脚本与CI保障
- 清理冗余的language相关翻译条目
- 调整主题脚本放置位置修复 hydration 警告
- 优化更新页面的请求取消与重复请求逻辑

## Summary by Sourcery

引入 API 错误码与 i18n key 之间的类型化、标准化映射，并配套提供工具链、文档以及 UI 微调，以提升健壮性和用户体验。

New Features:
- 添加 `ApiErrorCode` 联合类型，用于集中管理并强类型化所有已知的 API 错误码。
- 在 i18n 检查脚本中引入交叉引用检查，用于在检查过程中验证 `ApiError` 的使用及其对应的 i18n 映射。

Bug Fixes:
- 修复由于 `beforeInteractive` 主题脚本被放置在 `<body>` 内而导致的 hydration 警告。
- 确保更新页面在防止并发请求的同时，正确重置加载和错误状态。

Enhancements:
- 优化 `getErrorI18nKey`，改为使用类型安全的 `Record<ApiErrorCode, string>` 映射，并新增 `auth_unavailable` 客户端错误。
- 改进更新页面的更新日志获取逻辑，以便在请求进行中时可以取消，并在检查后避免不必要的重复刷新。
- 将用于防止主题 FOUC 的脚本移动到 `<head>` 中，以消除 React hydration 警告。
- 记录添加新错误码及其 i18n 映射所需遵循的工作流和约束。

Build:
- 扩展 i18n 检查脚本，以验证“错误码到 i18n key”映射的覆盖率以及在各语言环境中的存在情况，从而影响 CI 结果。

CI:
- 强化 CI，当 `ApiError` 错误码缺少映射或映射的 i18n key 在语言文件中缺失时使构建失败。

Documentation:
- 在 `AGENTS.md` 中添加指南，描述“错误码到 i18n 映射”的必需流程以及相关的自动化保障。

Chores:
- 清理各语言环境 JSON 文件和已知 key 配置中冗余或已废弃的、与语言相关的 i18n 条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a typed, standardized mapping between API error codes and i18n keys, with accompanying tooling, documentation, and UI tweaks to improve robustness and UX.

New Features:
- Add ApiErrorCode union type to centralize and strongly type all known API error codes.
- Introduce a cross-reference check that validates ApiError usages and their i18n mappings during the i18n check script.

Bug Fixes:
- Fix a hydration warning caused by a beforeInteractive theme script being placed inside <body>.
- Ensure the update page correctly resets loading and error states while preventing overlapping fetches.

Enhancements:
- Refine getErrorI18nKey to use a type-safe Record<ApiErrorCode, string> mapping and include a new auth_unavailable client-side error.
- Improve the update page changelog fetch logic to cancel in-flight requests and avoid redundant reloads after checks.
- Move the theme FOUC-prevention script into <head> to eliminate React hydration warnings.
- Document the required workflow and constraints for adding new error codes and their i18n mappings.

Build:
- Extend the i18n check script to validate error-code-to-i18n-key coverage and locale presence, affecting CI outcomes.

CI:
- Strengthen CI by failing builds when ApiError codes lack mappings or mapped i18n keys are missing from locale files.

Documentation:
- Add guidelines describing the mandatory error-code-to-i18n mapping process and automated guarantees in AGENTS.md.

Chores:
- Clean up redundant or obsolete language-related i18n entries across locale JSON files and known-keys configuration.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 新增错误码国际化映射规范与交叉验证机制，确保所有错误提示的国际化一致性
  * 新增"登录与云同步不可用"状态提示

* **Bug Fixes**
  * 改进主题脚本执行时机，防止页面闪烁
  * 优化更新页面的 Changelog 加载逻辑，提升加载体验

* **Documentation**
  * 更新错误码管理规范文档

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmyyx/cep/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->