### PR TITLE
Beta 0.2.18

### DIFF
--- a/public/debug-panel.js
+++ b/public/debug-panel.js
@@ -96,7 +96,7 @@
       }).catch(function () {
         callback(null)
       })
-    } catch (e) {
+    } catch {
       callback(null)
     }
   }
@@ -321,7 +321,7 @@
     try {
       document.execCommand('copy')
       showToast('Copied to clipboard')
-    } catch (e) {
+    } catch {
       alert(
         'Copy failed. Please select and copy manually:\n\n' + text.substring(0, 2000)
       )

--- a/public/debug-panel.js
+++ b/public/debug-panel.js
@@ -1,0 +1,446 @@
+/**
+ * Debug panel — loaded on demand via <script> injection.
+ * Placed in public/ so it's served as a static asset.
+ *
+ * Defines window.__cep_debug__._openPanel() and builds a pure-DOM
+ * log viewer with filtering, copy, export, and env info.
+ *
+ * ================================================================
+ * AGENTS.md EXCEPTION NOTES:
+ * ================================================================
+ *
+ * 1. **Inline styles (style attribute on DOM elements)**:
+ *    CRASH-RECOVERY TOOL — see bootstrap.ts for full justification.
+ *
+ * 2. **Bare DOM elements and innerHTML**:
+ *    LAST-RESORT debug surface — see bootstrap.ts for full justification.
+ *
+ * 3. **No TypeScript — plain JS**:
+ *    This file is served as a raw static asset; it must be valid JS
+ *    without any build step. TSC is configured to ignore public/.
+ * ================================================================
+ */
+
+;(function () {
+  // Guard against double-load
+  if (window.__cep_debug__ && window.__cep_debug__._openPanel) return
+
+  var api = window.__cep_debug__
+  if (!api) return // bootstrap not loaded yet
+
+  var panelVisible = false
+  var panelEl = null
+  var currentFilter = 'all'
+  var refreshTimer = null // interval for live-updating log display
+
+  // ---- helpers ----
+
+  function setFilter(f) {
+    currentFilter = f
+    var all = document.querySelectorAll('[id^="__d_filter_"]')
+    for (var i = 0; i < all.length; i++) {
+      all[i].style.fontWeight = all[i].id === '__d_filter_' + f ? '600' : '400'
+    }
+    renderLogs()
+  }
+
+  function redact(text) {
+    return text
+      .replace(
+        /(accessToken|refreshToken|token|password|secret|authorization|credential|key):\s*[^,}\s]+/gi,
+        '$1: [REDACTED]'
+      )
+      .replace(/^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/, '[REDACTED]')
+      .replace(/^sk-[A-Za-z0-9]{20,}$/, '[REDACTED]')
+  }
+
+  function esc(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+  }
+
+  // ---- integrity (SHA-256) ----
+
+  function buildLogPayload() {
+    var logs = api.getLogs()
+    var redacted = []
+    for (var i = 0; i < logs.length; i++) {
+      var e = logs[i]
+      redacted.push({
+        time: new Date(e.t).toISOString(),
+        level: e.l,
+        message: redact(e.a.join(' ')),
+      })
+    }
+    return redacted
+  }
+
+  function computeIntegrity(logsArray, callback) {
+    if (!window.crypto || !window.crypto.subtle) {
+      callback(null)
+      return
+    }
+    try {
+      var json = JSON.stringify(logsArray)
+      var enc = new TextEncoder().encode(json)
+      window.crypto.subtle.digest('SHA-256', enc).then(function (hash) {
+        var hex = Array.prototype.map
+          .call(new Uint8Array(hash), function (b) {
+            return ('00' + b.toString(16)).slice(-2)
+          })
+          .join('')
+        callback(hex)
+      }).catch(function () {
+        callback(null)
+      })
+    } catch (e) {
+      callback(null)
+    }
+  }
+
+  // ---- create panel DOM ----
+
+  function createPanel() {
+    panelEl = document.createElement('div')
+    panelEl.id = '__cep_debug_panel'
+    /* Panel: fixed height 60vh, flex column layout.
+       Only the log area scrolls; header + footer stay fixed. */
+    panelEl.setAttribute(
+      'style',
+      'display:flex;flex-direction:column;' +
+        'position:fixed;bottom:0;left:0;right:0;z-index:2147483646;' +
+        'height:60vh;max-height:60vh;overflow:hidden;' +         /* fixed height, no panel-level scroll */
+        'background:#1a1a1a;color:#e0e0e0;' +
+        'font-family:monospace;font-size:12px;line-height:1.5;' +
+        'padding:12px;' +
+        'border-top:2px solid #444;' +
+        'box-shadow:0 -4px 24px rgba(0,0,0,0.5);'
+    )
+
+    /* -- header (fixed) -- */
+    var header = document.createElement('div')
+    header.setAttribute(
+      'style',
+      'flex-shrink:0;' +                                           /* don't shrink */
+        'display:flex;justify-content:space-between;align-items:center;' +
+        'margin-bottom:8px;padding-bottom:6px;border-bottom:1px solid #333;'
+    )
+    header.innerHTML =
+      '<span style="font-weight:600;color:#fff;font-size:13px;">Debug Console</span>' +
+      '<div style="display:flex;gap:4px;flex-wrap:wrap;">' +
+      '<button id="__d_filter_all" class="__d_filter" data-f="all" style="' +
+      BTN_STYLE +
+      'font-weight:600;">All</button>' +
+      '<button id="__d_filter_error" class="__d_filter" data-f="error" style="' +
+      BTN_STYLE +
+      'color:#ff6b6b;">Errors</button>' +
+      '<button id="__d_filter_warn" class="__d_filter" data-f="warn" style="' +
+      BTN_STYLE +
+      'color:#ffd93d;">Warn</button>' +
+      '<button id="__d_filter_resource" class="__d_filter" data-f="resource" style="' +
+      BTN_STYLE +
+      'color:#6bcbff;">Res</button>' +
+      '<button id="__d_copy" style="' +
+      BTN_STYLE +
+      '">Copy</button>' +
+      '<button id="__d_export" style="' +
+      BTN_STYLE +
+      '">Export</button>' +
+      '<button id="__d_close" style="' +
+      BTN_STYLE +
+      'background:rgba(255,255,255,0.12);">Close</button>' +
+      '</div>'
+    panelEl.appendChild(header)
+
+    /* -- log container (scrollable, fills remaining space) -- */
+    var logContainer = document.createElement('div')
+    logContainer.id = '__d_logs'
+    logContainer.setAttribute(
+      'style',
+      'flex:1 1 0;min-height:0;overflow-y:auto;' +                 /* fill height, scroll internally */
+        '-webkit-overflow-scrolling:touch;overscroll-behavior:contain;'
+    )
+    panelEl.appendChild(logContainer)
+
+    /* -- env info footer (fixed) -- */
+    var envEl = document.createElement('div')
+    envEl.id = '__d_env'
+    envEl.setAttribute(
+      'style',
+      'flex-shrink:0;' +                                           /* don't shrink */
+        'margin-top:6px;padding-top:6px;border-top:1px solid #333;' +
+        'font-size:11px;color:#888;'
+    )
+    panelEl.appendChild(envEl)
+
+    document.body.appendChild(panelEl)
+
+    /* Delegate all button clicks at document level (capture phase).
+       This survives Next.js error overlay which registers its own
+       document capture handler that calls stopPropagation().
+       Same-node same-phase handlers fire in registration order;
+       stopPropagation only blocks children, not siblings. */
+    document.addEventListener('click', function (e) {
+      var id = e.target.id
+      if (id === '__d_copy') { copyLogs(); return }
+      if (id === '__d_export') { exportLogs(); return }
+      if (id === '__d_close') { closePanel(); return }
+      if (id === '__d_filter_all') { setFilter('all'); return }
+      if (id === '__d_filter_error') { setFilter('error'); return }
+      if (id === '__d_filter_warn') { setFilter('warn'); return }
+      if (id === '__d_filter_resource') { setFilter('resource'); return }
+    }, true)
+  }
+
+  var BTN_STYLE =
+    'padding:4px 10px;background:rgba(255,255,255,0.08);color:#ccc;border:1px solid rgba(255,255,255,0.12);border-radius:4px;font-size:11px;font-family:system-ui;cursor:pointer;white-space:nowrap;'
+
+  // ---- render ----
+
+  function renderLogs() {
+    var logContainer = document.getElementById('__d_logs')
+    var envEl = document.getElementById('__d_env')
+    if (!logContainer || !envEl) return
+
+    var logs = api.getLogs()
+    var filtered =
+      currentFilter === 'all'
+        ? logs
+        : logs.filter(function (e) {
+            return (
+              e.l === currentFilter ||
+              (currentFilter === 'error' && (e.l === 'error' || e.l === 'resource'))
+            )
+          })
+
+    var html = ''
+    if (filtered.length === 0) {
+      html =
+        '<div style="color:#666;padding:20px;text-align:center;">No entries yet.</div>'
+    } else {
+      for (var i = 0; i < filtered.length; i++) {
+        var e = filtered[i]
+        var lc =
+          e.l === 'error'
+            ? '#ff6b6b'
+            : e.l === 'warn'
+              ? '#ffd93d'
+              : e.l === 'resource'
+                ? '#6bcbff'
+                : '#aaa'
+        var ts = new Date(e.t).toLocaleTimeString()
+        var tx = e.a
+          .map(function (s) {
+            return redact(s)
+          })
+          .join(' ')
+        html +=
+          '<div style="padding:3px 0;border-bottom:1px solid rgba(255,255,255,0.04);word-break:break-all;">' +
+          '<span style="color:#666;">' +
+          ts +
+          '</span>' +
+          '<span style="color:' +
+          lc +
+          ';margin-left:8px;">[' +
+          e.l.toUpperCase() +
+          ']</span>' +
+          '<span style="color:#ddd;margin-left:8px;">' +
+          esc(tx) +
+          '</span>' +
+          '</div>'
+      }
+    }
+    logContainer.innerHTML = html
+
+    // Env info
+    var env = api.getEnv()
+    var keys = Object.keys(env)
+    var envHtml = ''
+    for (var k = 0; k < keys.length; k++) {
+      envHtml +=
+        '<span style="margin-right:16px;"><strong>' +
+        esc(keys[k]) +
+        ':</strong> ' +
+        esc(String(env[keys[k]])) +
+        '</span>'
+    }
+    envEl.innerHTML = envHtml
+  }
+
+  // ---- actions ----
+
+  function copyLogs() {
+    var logs = api.getLogs()
+    var text = ''
+    for (var i = 0; i < logs.length; i++) {
+      var e = logs[i]
+      text +=
+        '[' +
+        new Date(e.t).toISOString() +
+        '] [' +
+        e.l.toUpperCase() +
+        '] ' +
+        redact(e.a.join(' ')) +
+        '\n'
+    }
+
+    // Append integrity line
+    var payload = buildLogPayload()
+    computeIntegrity(payload, function (hash) {
+      var fullText = text
+      if (hash) {
+        fullText += '\n--- Integrity: sha256:' + hash + ' (' + payload.length + ' entries) ---'
+      } else {
+        fullText += '\n--- Integrity: unavailable (non-HTTPS) ---'
+      }
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(fullText).then(
+          function () {
+            showToast('Copied ' + logs.length + ' entries')
+          },
+          function () {
+            fallbackCopy(fullText)
+          }
+        )
+      } else {
+        fallbackCopy(fullText)
+      }
+    })
+  }
+
+  function fallbackCopy(text) {
+    var ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('style', 'position:fixed;top:-9999px;')
+    document.body.appendChild(ta)
+    ta.select()
+    try {
+      document.execCommand('copy')
+      showToast('Copied to clipboard')
+    } catch (e) {
+      alert(
+        'Copy failed. Please select and copy manually:\n\n' + text.substring(0, 2000)
+      )
+    }
+    document.body.removeChild(ta)
+  }
+
+  function exportLogs() {
+    var env = api.getEnv()
+    var payload = buildLogPayload()
+
+    computeIntegrity(payload, function (hash) {
+      var data = {
+        env: env,
+        logs: payload,
+        integrity: hash
+          ? {
+              algorithm: 'sha256',
+              hash: hash,
+              entryCount: payload.length,
+            }
+          : {
+              algorithm: 'none',
+              note: 'integrity unavailable (non-HTTPS context)',
+              entryCount: payload.length,
+            },
+      }
+
+      var blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+      var url = URL.createObjectURL(blob)
+      var a = document.createElement('a')
+      a.href = url
+      a.download = 'cep-debug-' + Date.now() + '.json'
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+      showToast('Exported ' + payload.length + ' log entries')
+    })
+  }
+
+  function showToast(msg) {
+    var t = document.createElement('div')
+    t.textContent = msg
+    /* INLINE STYLE — crash-recovery tool */
+    t.setAttribute(
+      'style',
+      'position:fixed;top:12px;left:50%;transform:translateX(-50%);z-index:2147483647;' +
+        'background:rgba(0,0,0,0.85);color:#fff;padding:8px 16px;border-radius:6px;' +
+        'font-family:system-ui;font-size:13px;pointer-events:none;' +
+        'animation:__cep_toast 2.2s ease forwards;'
+    )
+    document.body.appendChild(t)
+    setTimeout(function () {
+      if (t.parentNode) t.parentNode.removeChild(t)
+    }, 2300)
+  }
+
+  // ---- open / close ----
+
+  var REFRESH_MS = 500
+
+  function startRefresh() {
+    stopRefresh()
+    refreshTimer = setInterval(renderLogs, REFRESH_MS)
+  }
+
+  function stopRefresh() {
+    if (refreshTimer) {
+      clearInterval(refreshTimer)
+      refreshTimer = null
+    }
+  }
+
+  function openPanelOnly() {
+    /* Hide the floating label while panel is visible */
+    var lbl = document.getElementById('__cep_debug_label')
+    if (lbl) lbl.style.display = 'none'
+
+    if (!panelEl) {
+      createPanel()
+      panelVisible = true
+      renderLogs()
+      startRefresh()
+      return
+    }
+    if (!panelVisible) {
+      panelVisible = true
+      panelEl.style.display = 'flex'   /* flex, not block, because panel is flex container */
+      renderLogs()
+      startRefresh()
+    }
+  }
+
+  function closePanel() {
+    stopRefresh()
+    if (panelEl && panelVisible) {
+      panelVisible = false
+      panelEl.style.display = 'none'
+    }
+    /* Restore the label if it still exists (may have been auto-hidden by onload timer) */
+    var lbl = document.getElementById('__cep_debug_label')
+    if (lbl) lbl.style.display = ''
+  }
+
+  // ---- inject toast animation ----
+  var styleEl = document.createElement('style')
+  styleEl.textContent =
+    '@keyframes __cep_toast{0%{opacity:0;transform:translateX(-50%) translateY(-8px)}' +
+    '15%{opacity:1;transform:translateX(-50%) translateY(0)}' +
+    '85%{opacity:1;transform:translateX(-50%) translateY(0)}' +
+    '100%{opacity:0;transform:translateX(-50%) translateY(-8px)}}'
+  document.head.appendChild(styleEl)
+
+  // ---- expose ----
+
+  api._openPanel = openPanelOnly
+  api._togglePanel = function () {
+    if (panelVisible) closePanel()
+    else openPanelOnly()
+  }
+})()

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useSyncExternalStore } from 'react'
 import { useTranslations } from 'next-intl'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { Separator } from '@/components/ui/separator'
@@ -18,22 +18,24 @@ function getGreetingKey(): string {
   return 'home.greetingEvening'
 }
 
+/** Stable placeholder used during SSR/hydration to avoid mismatch. */
+const PLACEHOLDER_GREETING = 'home.greetingMorning'
+
 export default function HomePage() {
   const t = useTranslations()
-  const [greetingKey, setGreetingKey] = useState(() => getGreetingKey())
 
-  const updateGreeting = useCallback(() => {
-    setGreetingKey((prev) => {
-      const next = getGreetingKey()
-      return prev !== next ? next : prev
-    })
-  }, [])
-
-  useEffect(() => {
-    // Re-check every minute so the greeting updates near time boundaries
-    const interval = setInterval(updateGreeting, 60_000)
-    return () => clearInterval(interval)
-  }, [updateGreeting])
+  // useSyncExternalStore: server snapshot is the stable placeholder (no
+  // Date.now() during SSG), client snapshot is the real greeting. React
+  // handles the transition from server→client without hydration errors.
+  const greetingKey = useSyncExternalStore(
+    // Re-check every 60s so greeting updates near time boundaries
+    (onStoreChange) => {
+      const id = setInterval(onStoreChange, 60_000)
+      return () => clearInterval(id)
+    },
+    () => getGreetingKey(),
+    () => PLACEHOLDER_GREETING,
+  )
 
   return (
     <div className="flex flex-col flex-1 min-h-0">

--- a/src/app/[locale]/settings/page.tsx
+++ b/src/app/[locale]/settings/page.tsx
@@ -11,6 +11,7 @@ import { Upload } from 'lucide-react'
 import { DataCleaner } from '@/components/shared/data-cleaner'
 import { DataExporter } from '@/components/shared/data-exporter'
 import { DataImporter } from '@/components/shared/data-importer'
+import { openDebugConsole } from '@/components/shared/debug-console'
 import {
   Select,
   SelectContent,
@@ -178,6 +179,25 @@ export default function SettingsPage() {
               </div>
               <DataImporter />
             </div>
+          </div>
+        </section>
+
+        {/* 分隔线 */}
+        <div className="h-px bg-border" />
+
+        {/* 调试控制台入口 */}
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-medium text-muted-foreground">Debug</h2>
+          <div className="flex items-center justify-between py-2">
+            <div className="flex flex-col gap-1">
+              <span className="text-sm">Debug Console</span>
+              <span className="text-xs text-muted-foreground">
+                View captured console logs, errors, and environment info.
+              </span>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => openDebugConsole()}>
+              Open
+            </Button>
           </div>
         </section>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { HeadScript } from "@/components/shared/head-script";
+import { DEBUG_BOOTSTRAP_CODE } from "@/lib/debug/bootstrap";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -48,6 +49,14 @@ export default function RootLayout({
           id="theme-fouc"
           code={`(function(){try{var d=document.documentElement;var t="auto";var s=localStorage.getItem("cep-settings");if(s){var p=JSON.parse(s);t=p.theme||"auto"}if(t==="auto"){t=window.matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light"}if(t&&t!=="auto"){d.classList.add(t);if(t==="flashbang"){d.style.colorScheme="dark";d.setAttribute("data-theme","flashbang")}}}catch(e){}})()`}
         />
+        {/* Debug capture — hooks console + global errors before any other script runs.
+            Creates a [DEBUG] label (bottom-right) during page load as crash-recovery entry point.
+            AGENTS.md exception: inline styles + bare DOM elements — this is a devtools-style
+            debug surface that MUST function when React and external CSS are unavailable. */}
+        <HeadScript id="debug-bootstrap" code={DEBUG_BOOTSTRAP_CODE} />
+        {/* Preload + execute the debug panel early, so the [DEBUG] button works
+            without network delay. Uses afterInteractive so it doesn't block hydration. */}
+        <Script src="/debug-panel.js" strategy="afterInteractive" />
       </head>
       <body className="min-h-full flex flex-col">
         <TooltipProvider>{children}</TooltipProvider>

--- a/src/components/home/greeting-section.tsx
+++ b/src/components/home/greeting-section.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useSyncExternalStore } from 'react'
 import { useTranslations, useLocale } from 'next-intl'
 
 interface GreetingSectionProps {
@@ -20,22 +20,25 @@ function formatDateStr(locale: string): string {
   }
 }
 
+/** Stable placeholder used during SSR/hydration to avoid mismatch. */
+const PLACEHOLDER_DATE = ''
+
 export function GreetingSection({ greetingKey }: GreetingSectionProps) {
   const t = useTranslations()
   const locale = useLocale()
 
-  const [todayStr, setTodayStr] = useState(() => formatDateStr(locale))
-
-  const updateDate = useCallback(() => {
-    const next = formatDateStr(locale)
-    setTodayStr((prev) => (prev !== next ? next : prev))
-  }, [locale])
-
-  useEffect(() => {
-    // Periodic re-check so the date updates within 60s of midnight
-    const interval = setInterval(updateDate, 60_000)
-    return () => clearInterval(interval)
-  }, [updateDate])
+  // useSyncExternalStore: server snapshot is the empty string (no Date()
+  // during SSG), client snapshot is the real formatted date. React
+  // handles the transition from server→client without hydration errors.
+  const todayStr = useSyncExternalStore(
+    // Re-check every 60s so date updates near midnight
+    (onStoreChange) => {
+      const id = setInterval(onStoreChange, 60_000)
+      return () => clearInterval(id)
+    },
+    () => formatDateStr(locale),
+    () => PLACEHOLDER_DATE,
+  )
 
   return (
     <div className="space-y-1">

--- a/src/components/home/real-time-clock.tsx
+++ b/src/components/home/real-time-clock.tsx
@@ -1,30 +1,36 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 
 function formatTime(date: Date): string {
   const pad = (n: number) => String(n).padStart(2, '0')
   return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
 }
 
+/** Stable placeholder used during SSR/hydration to avoid mismatch. */
+const PLACEHOLDER_TIME = '--:--:--'
+
 export function RealTimeClock() {
-  const [time, setTime] = useState(() => formatTime(new Date()))
-
-  useEffect(() => {
-    let interval: ReturnType<typeof setInterval> | undefined
-
-    // Align to the next whole second for clean tick boundaries
-    const msToNext = 1000 - new Date().getMilliseconds()
-    const timeout = setTimeout(() => {
-      setTime(formatTime(new Date()))
-      interval = setInterval(() => setTime(formatTime(new Date())), 1000)
-    }, msToNext)
-
-    return () => {
-      clearTimeout(timeout)
-      if (interval) clearInterval(interval)
-    }
-  }, [])
+  // useSyncExternalStore: server snapshot is the placeholder (no Date()
+  // during SSG), client snapshot is the real time. React handles the
+  // transition from server→client without hydration errors.
+  const time = useSyncExternalStore(
+    (onStoreChange) => {
+      let interval: ReturnType<typeof setInterval>
+      // Align to the next whole second for clean tick boundaries
+      const msToNext = 1000 - new Date().getMilliseconds()
+      const timeout = setTimeout(() => {
+        onStoreChange()
+        interval = setInterval(onStoreChange, 1000)
+      }, msToNext)
+      return () => {
+        clearTimeout(timeout)
+        clearInterval(interval)
+      }
+    },
+    () => formatTime(new Date()),
+    () => PLACEHOLDER_TIME,
+  )
 
   return (
     <p className="text-4xl font-semibold tracking-[-2.4px] text-foreground tabular-nums">

--- a/src/components/shared/debug-console.tsx
+++ b/src/components/shared/debug-console.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+/**
+ * Lightweight trigger for the debug console.
+ *
+ * Renders nothing visible. Exports `openDebugConsole()` which opens
+ * the pure-DOM debug panel (from /debug-panel.js), loading it on
+ * demand if it hasn't been executed yet.
+ *
+ * The panel UI is defined in public/debug-panel.js — a single source
+ * of truth that works with or without React.
+ */
+
+let panelLoadPromise: Promise<void> | null = null
+
+/** Ensure debug-panel.js is loaded and executed. Idempotent. */
+function ensurePanelLoaded(): Promise<void> {
+  // Already loaded (by layout.tsx afterInteractive Script or previous call)
+  // @ts-expect-error __cep_debug__ is set by the bootstrap inline script
+  if (window.__cep_debug__?._openPanel) return Promise.resolve()
+
+  if (!panelLoadPromise) {
+    panelLoadPromise = new Promise<void>((resolve) => {
+      const script = document.createElement('script')
+      script.src = '/debug-panel.js'
+      script.async = true
+      script.onload = () => resolve()
+      script.onerror = () => {
+        panelLoadPromise = null
+        resolve() // resolve anyway — bootstrap's openPanel() fallback will try its own load
+      }
+      document.head.appendChild(script)
+    })
+  }
+  return panelLoadPromise
+}
+
+/**
+ * Open the debug console panel.
+ *
+ * If debug-panel.js hasn't been loaded yet, loads it first, then opens.
+ * Safe to call at any time — even before React hydrates.
+ */
+export async function openDebugConsole(): Promise<void> {
+  await ensurePanelLoaded()
+  // @ts-expect-error __cep_debug__._openPanel is defined by debug-panel.js
+  window.__cep_debug__?._openPanel?.()
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -23,6 +23,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useTranslations } from "next-intl"
 import { PanelLeftIcon } from "lucide-react"
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
@@ -268,8 +269,10 @@ function SidebarTrigger({
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar()
+  const t = useTranslations()
+  const tooltipText = t("sidebar.toggle")
 
-  return (
+  const button = (
     <Button
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
@@ -283,8 +286,17 @@ function SidebarTrigger({
       {...props}
     >
       <PanelLeftIcon />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{tooltipText}</span>
     </Button>
+  )
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={button} />
+      <TooltipContent side="right" align="center">
+        {tooltipText}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -4,6 +4,8 @@ import * as React from "react"
 import { mergeProps } from "@base-ui/react/merge-props"
 import { useRender } from "@base-ui/react/use-render"
 import { cva, type VariantProps } from "class-variance-authority"
+import { useTranslations } from "next-intl"
+import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
@@ -23,9 +25,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { useTranslations } from "next-intl"
-import { PanelLeftIcon } from "lucide-react"
-
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
@@ -71,18 +70,20 @@ function SidebarProvider({
   const [openMobile, setOpenMobile] = React.useState(false)
 
   // Always initialise with defaultOpen to keep SSG HTML and first client render identical.
-  const [_open, _setOpen] = React.useState(defaultOpen)
+  // useReducer dispatch is stable and safe to call from effects (unlike useState setters).
+  const [_open, _dispatchOpen] = React.useReducer(
+    (_state: boolean, action: boolean) => action,
+    defaultOpen
+  )
 
-  /* eslint-disable react-hooks/set-state-in-effect -- one-time hydration from external storage */
   React.useLayoutEffect(() => {
     const match = document.cookie.match(
       new RegExp(`(?:^|; )${SIDEBAR_COOKIE_NAME}=([^;]*)`)
     )
     if (match) {
-      _setOpen(match[1] === 'true')
+      _dispatchOpen(match[1] === 'true')
     }
   }, [])
-  /* eslint-enable react-hooks/set-state-in-effect */
   const open = openProp ?? _open
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
@@ -90,7 +91,7 @@ function SidebarProvider({
       if (setOpenProp) {
         setOpenProp(openState)
       } else {
-        _setOpen(openState)
+        _dispatchOpen(openState)
       }
 
       // This sets the cookie to keep the sidebar state.

--- a/src/hooks/use-version.tsx
+++ b/src/hooks/use-version.tsx
@@ -118,7 +118,14 @@ export function VersionProvider({ children, initialInfo }: { children: ReactNode
   }, [localInfo])
 
   const checkNow = useCallback(() => { fetchVersion(true) }, [fetchVersion])
-  const refreshPage = useCallback(() => { window.location.reload() }, [])
+  // Use location.replace() instead of reload() — on mobile browsers,
+  // reload() may restore from bfcache or skip resource re-download,
+  // causing CSS/JS version mismatch. replace() performs a full
+  // navigation (identical to user typing the URL), which guarantees
+  // all resources are re-requested with proper cache negotiation.
+  const refreshPage = useCallback(() => {
+    window.location.replace(window.location.href)
+  }, [])
 
   useEffect(() => {
     // 首次加载 + 定时轮询 + 获焦检测

--- a/src/hooks/use-version.tsx
+++ b/src/hooks/use-version.tsx
@@ -119,10 +119,10 @@ export function VersionProvider({ children, initialInfo }: { children: ReactNode
 
   const checkNow = useCallback(() => { fetchVersion(true) }, [fetchVersion])
   // Use location.replace() instead of reload() — on mobile browsers,
-  // reload() may restore from bfcache or skip resource re-download,
-  // causing CSS/JS version mismatch. replace() performs a full
-  // navigation (identical to user typing the URL), which guarantees
-  // all resources are re-requested with proper cache negotiation.
+  // reload() may restore from bfcache (no network request), causing
+  // CSS/JS version mismatch. replace() performs a full navigation
+  // which bypasses bfcache. HTML freshness thereafter depends on
+  // Cache-Control headers (this project serves HTML with no-cache).
   const refreshPage = useCallback(() => {
     window.location.replace(window.location.href)
   }, [])

--- a/src/lib/debug/bootstrap.ts
+++ b/src/lib/debug/bootstrap.ts
@@ -1,0 +1,98 @@
+/**
+ * Mobile debug bootstrap — inline script injected into <head> via HeadScript.
+ *
+ * ================================================================
+ * AGENTS.md EXCEPTION NOTES:
+ * ================================================================
+ *
+ * 1. **Inline styles (style attribute on DOM elements)**:
+ *    CRASH-RECOVERY TOOL. When CSS is not loaded, the debug label MUST
+ *    render using only inline styles. Debug chrome only.
+ *
+ * 2. **Bare DOM elements (createElement, appendChild)**:
+ *    LAST-RESORT debugging surface. Must function when React/Shadcn
+ *    are unavailable. All DOM is scoped to __cep_debug__ prefix.
+ *
+ * 3. **`dangerouslySetInnerHTML`** (via HeadScript in layout.tsx):
+ *    Already covered by existing exception for head-script.tsx.
+ * ================================================================
+ */
+
+export const DEBUG_BOOTSTRAP_CODE = `(function(){
+var B=[],M=1000;
+function A(l,a){
+  var s=[];for(var i=0;i<a.length;i++){var v=a[i];try{s.push(typeof v==='string'?v:JSON.stringify(v))}catch(e){s.push(String(v))}}
+  B.push({l:l,t:Date.now(),a:s});if(B.length>M)B.shift();
+}
+(function(){var L=['debug','log','warn','error'];for(var i=0;i<L.length;i++){(function(lev){var o=console[lev].bind(console);console[lev]=function(){A(lev,Array.prototype.slice.call(arguments));o.apply(console,arguments)}})(L[i])}})();
+window.addEventListener('error',function(e){if(e.target===window||(e.target&&e.message))A('error',[e.message||'Unknown',(e.filename||'')+':'+(e.lineno||'')]);});
+window.addEventListener('error',function(e){var t=e.target;if(t&&(t instanceof HTMLLinkElement||t instanceof HTMLScriptElement||t instanceof HTMLImageElement))A('resource',[(t.tagName||'el').toLowerCase()+' failed: '+(t.href||t.src||'')])},true);
+window.addEventListener('unhandledrejection',function(e){A('error',['[Rejection]',e.reason])});
+window.__cep_debug__={getLogs:function(){return B.slice()},clear:function(){B.length=0},getEnv:function(){return{url:location.href,ua:navigator.userAgent,lang:navigator.language,plat:navigator.platform||'',size:innerWidth+'x'+innerHeight,dpr:String(devicePixelRatio||1),time:new Date().toISOString()}}};
+
+/* openPanel — always opens (used by label click and settings page).
+   togglePanel — toggles open/closed (used by 5-click gesture).
+   Both load /debug-panel.js on demand if not yet loaded. */
+function openPanel(){
+  if(window.__cep_debug__&&window.__cep_debug__._openPanel){
+    window.__cep_debug__._openPanel();return;
+  }
+  loadPanel(function(){if(window.__cep_debug__&&window.__cep_debug__._openPanel)window.__cep_debug__._openPanel()})
+}
+function togglePanel(){
+  if(window.__cep_debug__&&window.__cep_debug__._togglePanel){
+    window.__cep_debug__._togglePanel();return;
+  }
+  loadPanel(function(){if(window.__cep_debug__&&window.__cep_debug__._togglePanel)window.__cep_debug__._togglePanel()})
+}
+function loadPanel(cb){
+  var lbl=document.getElementById('__cep_debug_label');
+  if(lbl){lbl.textContent='Loading...';lbl.style.cursor='wait';lbl.style.opacity='0.7'}
+  var s=document.createElement('script');
+  s.src='/debug-panel.js';
+  s.onload=function(){
+    if(lbl){lbl.textContent='Debug Console';lbl.style.cursor='pointer';lbl.style.opacity='1'}
+    cb()
+  };
+  s.onerror=function(){
+    if(lbl){lbl.textContent='Debug Console';lbl.style.cursor='pointer';lbl.style.opacity='1'}
+    alert('Failed to load debug panel.')
+  };
+  document.head.appendChild(s);
+}
+
+/* Floating [DEBUG] label — visible during page load, auto-hides after
+   load completes. Pure DOM, no CSS/React dependency. Single-click opens. */
+(function(){
+  var label=document.createElement('button');
+  label.id='__cep_debug_label';
+  label.textContent='Debug Console';
+  label.setAttribute('style','position:fixed;bottom:12px;right:12px;z-index:2147483647;'+
+    'background:rgba(0,0,0,0.55);color:#fff;border:1px solid rgba(255,255,255,0.2);'+
+    'font-size:13px;padding:4px 10px;border-radius:4px;font-weight:500;'+
+    'letter-spacing:0.5px;cursor:pointer;'+
+    'font-family:system-ui,-apple-system,sans-serif;'+
+    '-webkit-tap-highlight-color:transparent;touch-action:manipulation;user-select:none;outline:none;'+
+    'transition:opacity 0.6s ease;opacity:1');
+  /* Bind via document capture delegation — survives Next.js error overlay
+     which calls stopPropagation() at document level. Child-bound handlers
+     never receive the event. */
+  label.setAttribute('data-debug','label');
+  (function a(){if(document.body)document.body.appendChild(label);else requestAnimationFrame(a)})();
+
+  /* Auto-hide after page finishes loading (window.onload + 3s grace) */
+  function hide(){label.style.opacity='0';setTimeout(function(){if(label.parentNode)label.parentNode.removeChild(label)},700)}
+  if(document.readyState==='complete'){setTimeout(hide,3000)}
+  else{window.addEventListener('load',function(){setTimeout(hide,3000)})}
+})();
+
+/* 5-click gesture + label click — both delegated on document (capture phase).
+   Child-bound handlers are unreachable when Next.js error overlay calls
+   stopPropagation() at document level. */
+var C=0,T=0;document.addEventListener('click',function(e){
+  /* Label click — check ancestors for data-debug="label" */
+  var t=e.target;while(t){if(t.getAttribute&&t.getAttribute('data-debug')==='label'){e.stopPropagation();openPanel();return}t=t.parentElement}
+  /* 5-click gesture (not on label) */
+  C++;if(T)clearTimeout(T);if(C>=5){C=0;togglePanel()}T=setTimeout(function(){C=0},1000)
+},true);
+})();`.replace(/\n\s*/g, '')

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -777,6 +777,7 @@
     "openInNewTab": "Embedded experience limited? Open in a new tab for the full forum experience."
   },
   "sidebar": {
+    "toggle": "Toggle Sidebar",
     "community": "Community",
     "communityDesc": "Feedback · Suggestions · Chat"
   },

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -777,6 +777,7 @@
     "openInNewTab": "埋め込み表示に制限がありますか？新しいタブで完全なフォーラム体験をご利用ください。"
   },
   "sidebar": {
+    "toggle": "サイドバーを切り替え",
     "community": "Community",
     "communityDesc": "フィードバック · 提案 · 交流"
   },

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -777,6 +777,7 @@
     "openInNewTab": "内嵌体验受限？在新标签页打开可获得完整论坛体验。"
   },
   "sidebar": {
+    "toggle": "切换侧边栏",
     "community": "Community",
     "communityDesc": "反馈 · 建议 · 交流"
   },

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -777,6 +777,7 @@
     "openInNewTab": "內嵌體驗受限？在新分頁開啟可獲得完整論壇體驗。"
   },
   "sidebar": {
+    "toggle": "切換側邊欄",
     "community": "Community",
     "communityDesc": "回饋 · 建議 · 交流"
   },


### PR DESCRIPTION
## Summary by Sourcery

引入具备崩溃恢复能力的客户端调试控制台，并改进基于时间的 UI 渲染和版本刷新行为。

新功能：
- 增加一个全局调试控制台，可通过页面内悬浮标签和设置页入口访问，由独立的基于 DOM 的调试面板提供支持，支持日志查看、筛选、复制和导出。
- 提供一个共享的调试控制台触发工具，可从 React 组件中以编程方式打开调试面板。

缺陷修复：
- 通过使用带稳定服务端占位内容的 `useSyncExternalStore`，避免时间相关 UI 元素（实时时钟、问候语和日期显示）的水合不匹配问题。
- 在移动端通过使用完整导航（`location.replace`）替代 `location.reload`，确保应用刷新时加载正确的静态资源版本。

增强改进：
- 使用基于 reducer 的内部状态优化侧边栏状态管理，并为侧边栏触发按钮添加本地化工具提示。
- 通过采用兼容服务端渲染的订阅模式进行周期性检查，提升基于时间的 UI 更新（问候语和日期）的健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a crash-resilient client-side debug console and improve time-based UI rendering and version refresh behavior.

New Features:
- Add a global debug console accessible via a floating in-page label and settings page entry, backed by a standalone DOM-based debug panel with log viewing, filtering, copying, and export.
- Expose a shared debug console trigger utility that can programmatically open the debug panel from React components.

Bug Fixes:
- Prevent hydration mismatches for time-dependent UI elements (real-time clock, greeting message, and date display) by switching to useSyncExternalStore with stable server placeholders.
- Ensure application refreshes load the correct asset versions on mobile by using full navigations (location.replace) instead of location.reload.

Enhancements:
- Refine sidebar state management with a reducer-based internal state and add a localized tooltip for the sidebar trigger button.
- Improve robustness of time-based UI updates (greeting and date) with periodic checks using a subscription-style pattern compatible with server rendering.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增调试控制台面板，支持日志查看、多维度过滤（全部/错误/警告/资源）、日志导出和复制功能
  * 在设置页面增加调试控制台快捷入口
  
* **改进**
  * 优化实时时钟和问候语的渲染稳定性，增强跨端兼容性
  * 改进页面刷新机制，防止移动设备缓存导致的资源版本不一致问题
  * 完善国际化支持，优化多语言文案

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cmyyx/cep/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->