### PR TITLE
refactor(planner): 重构S1选择逻辑，新增通用工具函数并修复隐藏武器影响选择的问题

### DIFF
--- a/src/components/essence/dungeon-card.tsx
+++ b/src/components/essence/dungeon-card.tsx
@@ -13,6 +13,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { ChevronDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { resolveStatI18nKey } from '@/data/stat-i18n-map'
+import { computeEffectiveS1 } from '@/lib/planner/s1-utils'
 
 interface DungeonCardProps {
   plan: DungeonPlan
@@ -424,11 +425,6 @@ export const DungeonCard = memo(function DungeonCard({
     toggleDungeonExpand(planKey)
   }, [toggleDungeonExpand, planKey])
 
-  const effectiveS1 = useMemo(() => {
-    if (!plan.needsS1Choice) return plan.s1Candidates
-    return dungeonS1Selections[planKey] || plan.selectedS1
-  }, [plan, planKey, dungeonS1Selections])
-
   // Filter matchedWeapons based on plan-side hide settings
   const visibleMatched = useMemo(() => {
     return plan.matchedWeapons.filter(({ weapon }) => {
@@ -466,6 +462,20 @@ export const DungeonCard = memo(function DungeonCard({
   const visibleS1Candidates = useMemo(() => {
     return plan.s1Candidates.filter((s1) => (visibleS1Counts[s1] || 0) > 0)
   }, [plan.s1Candidates, visibleS1Counts])
+
+  // Effective S1: filter against visible candidates so hidden-weapon stats
+  // never linger as "selected" when they have no visible weapons.
+  const effectiveS1 = useMemo(() => {
+    return computeEffectiveS1(
+      dungeonS1Selections[planKey],
+      plan.selectedS1,
+      visibleS1Candidates,
+    )
+  }, [plan.selectedS1, planKey, dungeonS1Selections, visibleS1Candidates])
+
+  // Whether the S1 picker is needed (based on visible candidates, not solver's
+  // original count which may include now-hidden weapons)
+  const visibleNeedsS1Choice = visibleS1Candidates.length > 3
 
   // Count selected weapons that are both visible and in S1 range
   const visibleSelected = useMemo(() => {
@@ -583,7 +593,7 @@ export const DungeonCard = memo(function DungeonCard({
       </div>
 
       {/* S1 Picker */}
-      {plan.needsS1Choice && (
+      {visibleNeedsS1Choice && (
         <div className="mb-3 p-3 rounded-md border border-amber-500/20 bg-amber-500/5">
           <p className="text-xs text-amber-600 mb-2">
             {t('essence.s1PickerHint', { candidates: visibleS1Candidates.length })}

--- a/src/lib/planner/s1-utils.test.ts
+++ b/src/lib/planner/s1-utils.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { computeEffectiveS1 } from './s1-utils'
+
+const ALL_S1 = ['力量提升', '敏捷提升', '智识提升', '意志提升', '主能力提升'] as const
+
+describe('computeEffectiveS1', () => {
+  // ── <= 3 visible candidates → use all visible, ignore stored/solver ──
+
+  it('returns all visible when <= 3 candidates (no choice needed)', () => {
+    const visible = ['力量提升', '敏捷提升']
+    expect(computeEffectiveS1(undefined, ['力量提升'], visible)).toEqual(visible)
+  })
+
+  it('returns all visible even when stored override exists', () => {
+    const visible = ['力量提升', '敏捷提升', '智识提升']
+    const stored = ['力量提升']
+    expect(computeEffectiveS1(stored, ['力量提升'], visible)).toEqual(visible)
+  })
+
+  it('returns empty when no visible candidates', () => {
+    expect(computeEffectiveS1(undefined, ['力量提升'], [])).toEqual([])
+  })
+
+  // ── > 3 visible candidates, no stored override ──
+
+  it('uses solver selection filtered to visible when no stored override', () => {
+    const visible = [...ALL_S1]
+    const solverS1 = ['力量提升', '敏捷提升', '智识提升']
+    expect(computeEffectiveS1(undefined, solverS1, visible)).toEqual(solverS1)
+  })
+
+  it('filters solver selection to only visible stats', () => {
+    const visible = ['力量提升', '敏捷提升', '智识提升', '意志提升']
+    // solver selected 主能力提升 which is not visible
+    const solverS1 = ['力量提升', '敏捷提升', '主能力提升']
+    const result = computeEffectiveS1(undefined, solverS1, visible)
+    expect(result).toEqual(['力量提升', '敏捷提升'])
+  })
+
+  it('falls back to visible when solver selection has no visible overlap', () => {
+    const visible = ['力量提升', '敏捷提升', '智识提升', '意志提升']
+    const solverS1 = ['主能力提升'] // not in visible
+    expect(computeEffectiveS1(undefined, solverS1, visible)).toEqual(visible)
+  })
+
+  // ── > 3 visible candidates, stored override exists ──
+
+  it('filters stored override to visible candidates', () => {
+    const visible = [...ALL_S1]
+    const stored = ['力量提升', '智识提升', '意志提升']
+    expect(computeEffectiveS1(stored, ['力量提升'], visible)).toEqual(stored)
+  })
+
+  it('excludes stored stats that are no longer visible', () => {
+    const visible = ['力量提升', '敏捷提升', '智识提升', '意志提升']
+    const stored = ['力量提升', '敏捷提升', '主能力提升'] // 主能力提升 hidden
+    const result = computeEffectiveS1(stored, ['力量提升'], visible)
+    expect(result).toEqual(['力量提升', '敏捷提升'])
+  })
+
+  it('falls back to solver selection when stored has no visible overlap', () => {
+    const visible = ['力量提升', '敏捷提升', '智识提升', '意志提升']
+    const stored = ['主能力提升'] // not in visible
+    const solverS1 = ['力量提升', '敏捷提升', '智识提升']
+    expect(computeEffectiveS1(stored, solverS1, visible)).toEqual(solverS1)
+  })
+
+  it('falls back to all visible when both stored and solver have no overlap', () => {
+    const visible = ['力量提升', '敏捷提升', '智识提升', '意志提升']
+    const stored = ['主能力提升']
+    const solverS1 = ['主能力提升']
+    expect(computeEffectiveS1(stored, solverS1, visible)).toEqual(visible)
+  })
+
+  // ── Real-world scenario: hiding reduces candidates from >3 to <=3 ──
+
+  it('auto-selects all visible when hiding reduces 5 candidates to 3', () => {
+    const visible = ['力量提升', '敏捷提升', '智识提升']
+    const stored = ['力量提升', '智识提升', '意志提升'] // 意志提升 was valid before
+    // With <= 3 visible, stored is ignored and all visible are returned
+    expect(computeEffectiveS1(stored, ['力量提升'], visible)).toEqual(visible)
+  })
+
+  it('auto-selects all visible when hiding reduces 4 candidates to 2', () => {
+    const visible = ['力量提升', '敏捷提升']
+    const stored = ['力量提升', '智识提升', '意志提升']
+    expect(computeEffectiveS1(stored, ['力量提升'], visible)).toEqual(visible)
+  })
+})

--- a/src/lib/planner/s1-utils.ts
+++ b/src/lib/planner/s1-utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Compute the effective S1 primary-stat selection for a dungeon plan,
+ * taking into account which S1 candidates are actually visible (i.e.
+ * have at least one non-hidden weapon).
+ *
+ * @param stored - User's manual S1 override from `dungeonS1Selections`, or `undefined` if none.
+ * @param solverSelectedS1 - Solver's auto-selected S1 stats (`plan.selectedS1`).
+ * @param visibleCandidates - S1 stats that have ≥ 1 visible weapon after hide filters.
+ * @returns The effective S1 stats to use for this plan card.
+ */
+export function computeEffectiveS1(
+  stored: string[] | undefined,
+  solverSelectedS1: string[],
+  visibleCandidates: string[],
+): string[] {
+  // <= 3 visible candidates → no choice needed, use all visible
+  if (visibleCandidates.length <= 3) return visibleCandidates
+
+  // No user override → use solver's auto-selection filtered to visible
+  if (!stored) {
+    const filtered = solverSelectedS1.filter((s) => visibleCandidates.includes(s))
+    return filtered.length > 0 ? filtered : visibleCandidates
+  }
+
+  // User override exists → filter to visible candidates
+  const filtered = stored.filter((s) => visibleCandidates.includes(s))
+  if (filtered.length > 0) return filtered
+
+  // Override fully invalid → fall back to solver auto-selection
+  const fallback = solverSelectedS1.filter((s) => visibleCandidates.includes(s))
+  return fallback.length > 0 ? fallback : visibleCandidates
+}


### PR DESCRIPTION
1. 新增computeEffectiveS1工具函数统一处理有效S1选择逻辑
2. 替换原有的useMemo计算逻辑，使用新工具函数过滤隐藏武器的无效S1选项
3. 新增可见S1选择器判断逻辑，基于实际可见候选数而非原始配置
4. 补充完整的单元测试覆盖各类边界场景

## Summary by Sourcery

在地城卡片中优化 S1 选择处理逻辑，仅基于可见的武器候选项，并将选择逻辑集中化。

新功能：
- 引入共享工具函数 `computeEffectiveS1`，基于可见候选项、求解器输出以及已存储的覆盖值，计算有效的 S1 选择结果。

缺陷修复：
- 防止当底层武器不再可见时，其对应的隐藏武器 S1 统计仍保持选中状态。
- 将 S1 选择器的可见性依据从原始求解器配置，改为当前可见的 S1 候选项数量。

增强改进：
- 用新的可复用工具函数替换地城卡片中的内联 S1 计算逻辑，使规划器行为更清晰。

测试：
- 为 `computeEffectiveS1` 添加覆盖可见性边界情况、覆盖值以及求解器回退行为的全面单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine S1 selection handling in dungeon cards to respect only visible weapon candidates and centralize the selection logic.

New Features:
- Introduce a shared computeEffectiveS1 utility to derive effective S1 selections based on visible candidates, solver output, and stored overrides.

Bug Fixes:
- Prevent hidden-weapon S1 stats from remaining selected when their underlying weapons are no longer visible.
- Base the S1 picker visibility on the count of visible S1 candidates instead of the original solver configuration.

Enhancements:
- Replace inline S1 computation in the dungeon card with the new reusable utility for clearer planner behavior.

Tests:
- Add comprehensive unit tests for computeEffectiveS1 covering visibility edge cases, overrides, and solver fallbacks.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了卡牌中武器选择候选的显示逻辑，确保应用隐藏过滤后仅保留可见的候选项。

* **Tests**
  * 新增测试用例覆盖武器选择计算在多种输入场景下的逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->