### PR TITLE
fix: 已选武器被隐藏时整个方案卡片不渲染

### DIFF
--- a/src/components/essence/dungeon-card.tsx
+++ b/src/components/essence/dungeon-card.tsx
@@ -617,9 +617,11 @@ export const DungeonCard = memo(function DungeonCard({
     return () => ro.disconnect()
   }, [isExpanded, recomputeAlign])
 
-  // Don't render plans where all weapons are hidden by hide filters —
-  // showing "selected: 0 / total: 0" is confusing and useless.
-  if (visibleTotal === 0) return null
+  // Don't render plans where all weapons are hidden, or where the plan has
+  // selected weapons but none survive hide filters — showing only unselected
+  // weapons is confusing (e.g. selecting 扶摇 but only seeing 楔子).
+  const hasVisibleSelected = visibleMatched.some((m) => m.isSelected)
+  if (visibleTotal === 0 || (plan.selectedCount > 0 && !hasVisibleSelected)) return null
 
   return (
     <div className="rounded-lg border border-border bg-card p-4">


### PR DESCRIPTION
Bug 描述：
当用户开启「隐藏基质已拥有武器」等方案侧隐藏设置时，
已选中的武器如果命中隐藏条件会被过滤掉，但方案卡片仍
会渲染剩余的未选中武器。例如：勾选扶摇（基质已拥有），
右侧方案卡中扶摇被隐藏，只剩共享相同属性的楔子可见，
用户看到的是「勾了扶摇却显示楔子」。

修复方案：
在 DungeonCard 的渲染守卫中增加检查：如果方案中没有任何
可见的已选武器（全部被隐藏设置过滤），整个方案卡片不渲染。
隐藏设置本身的逻辑不变，尊重用户的隐藏意图。

## Summary by Sourcery

错误修复：
- 修复地牢规划卡片在所有已选武器因用户配置的隐藏筛选器被隐藏时，只显示未选武器的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent dungeon plan cards from showing only unselected weapons when all selected weapons are hidden by user-configured hide filters.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 修复了地下城卡片的显示逻辑，现在仅在存在已选择的武器时才显示卡片，避免出现空白卡片显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->