### PR TITLE
feat(essence): 新增已选武器栏与弹窗查看功能，优化交互体验

### DIFF
--- a/scripts/.i18n-known-keys.json
+++ b/scripts/.i18n-known-keys.json
@@ -123,7 +123,13 @@
         "redeemInvalidDays",
         "redeemInvalidCount",
         "redeemInvalidExpiry",
-        "redeemInsufficientPermission"
+        "redeemInsufficientPermission",
+        "customWeaponsNotAllowed",
+        "invalidPlanType",
+        "invalidQuantity",
+        "serverError",
+        "tooManyPendingClaims",
+        "versionConflict"
       ]
     },
 
@@ -132,6 +138,16 @@
       "keys": [
         "offRateNote.tangtang",
         "offRateNote.luoxi"
+      ]
+    },
+
+    "holiday": {
+      "comment": "Holiday banner keys accessed via t(`${config.i18nKey}.banner`) in holiday-banner.tsx. The i18nKey comes from HOLIDAYS config at runtime.",
+      "keys": [
+        "childrensDay.banner",
+        "gameAnniversary.banner",
+        "newYear.banner",
+        "toolAnniversary.banner"
       ]
     }
   }

--- a/src/app/[locale]/essence-planner/page.tsx
+++ b/src/app/[locale]/essence-planner/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useCallback, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 import { usePathname } from 'next/navigation'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { Button } from '@/components/ui/button'
 import { WeaponGrid } from '@/components/essence/weapon-grid'
@@ -32,6 +33,7 @@ export default function EssencePlannerPage() {
   const [customWeaponOpen, setCustomWeaponOpen] = useState(false)
   const [mobileView, setMobileView] = useState<MobileView>('weapons')
   const [viewAllOpen, setViewAllOpen] = useState(false)
+  const isMobile = useIsMobile()
 
   // Dynamic region data from dungeon list
   const regions = useMemo(() => getRegions(dungeons), [])
@@ -465,7 +467,7 @@ export default function EssencePlannerPage() {
       {/* Desktop layout: left weapon grid + right plans */}
       <div className="hidden md:flex flex-1 overflow-hidden">
         <div className="grow min-w-96 max-w-[33.333%] border-r border-border overflow-y-scroll p-3 pb-16">
-          <WeaponGrid />
+          <WeaponGrid onViewAll={() => setViewAllOpen(true)} />
         </div>
         <div className="flex-1 overflow-y-auto p-4 pb-16">
           {renderPlanList()}
@@ -508,77 +510,99 @@ export default function EssencePlannerPage() {
         <div className="flex-1 min-h-0 overflow-y-auto">
           {mobileView === 'weapons' ? (
             <div className="p-3 pb-16">
-              <WeaponGrid />
+              <WeaponGrid onViewAll={() => setViewAllOpen(true)} />
             </div>
           ) : (
             <div className="p-4 pb-16">
-              {/* Selected weapons context header */}
-              {!noWeaponsSelected && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setViewAllOpen(true)}
-                  className="flex items-center gap-2 mb-3"
-                >
-                  <span>{t('essence.selectedCount', { count: selectedCount })}</span>
-                  <span className="text-xs">{t('essence.viewAllSelected')}</span>
-                </Button>
-              )}
               {renderPlanList()}
             </div>
           )}
         </div>
 
-        {/* Bottom bar — relative with margin-bottom for watermark clearance.
-            safe-area-inset handled via safe-area-mb utility. */}
+        {/* Bottom bar */}
         <div className="relative safe-area-mb z-40 flex items-center justify-between px-4 py-2.5 shadow-[inset_0px_1px_0px_0px_rgba(0,0,0,0.08)] bg-background">
           <span className="text-sm text-muted-foreground">
             {t('essence.selectedCount', { count: selectedCount })}
           </span>
-          {mobileView === 'weapons' ? (
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => setMobileView('plans')}
-              disabled={noWeaponsSelected}
-            >
-              {t('essence.viewPlans')}
-            </Button>
-          ) : (
+          <div className="flex items-center gap-2">
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setMobileView('weapons')}
+              onClick={() => setViewAllOpen(true)}
+              disabled={noWeaponsSelected}
             >
-              {t('essence.manageWeapons')}
+              {t('essence.selectedList')}
             </Button>
-          )}
+            {mobileView === 'weapons' ? (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => setMobileView('plans')}
+                disabled={noWeaponsSelected}
+              >
+                {t('essence.viewPlans')}
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setMobileView('weapons')}
+              >
+                {t('essence.manageWeapons')}
+              </Button>
+            )}
+          </div>
         </div>
       </div>
 
-      {/* "View All" selected weapons bottom sheet */}
-      <Sheet open={viewAllOpen} onOpenChange={setViewAllOpen}>
-        <SheetContent side="bottom" className="max-h-[70vh] overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle>{t('essence.selectedCount', { count: selectedCount })}</SheetTitle>
-          </SheetHeader>
-          <div className="grid grid-cols-3 gap-2 px-4 pb-4">
-            {selectedWeaponIds.map((id) => {
-              const weapon = allWeaponsMap.get(id)
-              if (!weapon) return null
-              return (
-                <WeaponCard
-                  key={id}
-                  weapon={weapon}
-                  isSelected={selectedSet.has(id)}
-                />
-              )
-            })}
-          </div>
-        </SheetContent>
-      </Sheet>
     </div>
+
+    {/* Selected weapons sheet (desktop: right panel, mobile: bottom sheet) */}
+    <Sheet open={viewAllOpen} onOpenChange={setViewAllOpen}>
+      <SheetContent
+        side={isMobile ? 'bottom' : 'right'}
+        className={cn(
+          'overflow-y-auto',
+          isMobile ? 'max-h-[70vh]' : '',
+        )}
+      >
+        <SheetHeader>
+          <SheetTitle>{t('essence.selectedCount', { count: selectedCount })}</SheetTitle>
+        </SheetHeader>
+        {!noWeaponsSelected && (
+          <div className="flex items-center gap-2 px-4 pb-3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => selectAllWeapons(useMatrixStore.getState().visibleWeaponIds)}
+            >
+              {t('essence.selectAll')}
+            </Button>
+            <Button variant="ghost" size="sm" onClick={clearWeapons}>
+              {t('essence.clearAll')}
+            </Button>
+          </div>
+        )}
+        <div className="grid grid-cols-3 gap-2 px-4 pb-4">
+          {selectedWeaponIds.map((id) => {
+            const weapon = allWeaponsMap.get(id)
+            if (!weapon) return null
+            return (
+              <WeaponCard
+                key={id}
+                weapon={weapon}
+                isSelected={selectedSet.has(id)}
+              />
+            )
+          })}
+        </div>
+        {noWeaponsSelected && (
+          <div className="flex items-center justify-center py-16 text-sm text-muted-foreground">
+            {t('essence.emptyHint')}
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
     </>
   )
 }

--- a/src/components/essence/dungeon-card.tsx
+++ b/src/components/essence/dungeon-card.tsx
@@ -163,7 +163,7 @@ const WeaponThumbnail = memo(function WeaponThumbnail({
     pointerStartRef.current = null
     if (longPressTriggeredRef.current) {
       setOpen(false)
-      longPressTriggeredRef.current = false
+      // Do NOT reset longPressTriggeredRef here — let handleToggle consume it
     }
   }, [clearLongPress])
 
@@ -182,8 +182,9 @@ const WeaponThumbnail = memo(function WeaponThumbnail({
   const weaponName = (weapon.id?.startsWith('custom-') || weapon.id?.startsWith('preview:')) ? weapon.name : (t(`weapons.${weapon.id}`) ?? weapon.name)
 
   const thumb = (
-    <button
-      type="button"
+    <Button
+      variant="ghost"
+      size="icon"
       ref={triggerRef}
       onClick={handleToggle}
       onPointerDown={isMobile && enableTooltip ? handlePointerDown : undefined}
@@ -216,7 +217,7 @@ const WeaponThumbnail = memo(function WeaponThumbnail({
           <Check className="size-2.5 text-black" strokeWidth={3} />
         </div>
       )}
-    </button>
+    </Button>
   )
 
   if (!enableTooltip) return thumb
@@ -273,8 +274,9 @@ const WeaponRow = memo(function WeaponRow({
       )}
     >
       <div className="flex items-center gap-2 min-w-0 shrink-0">
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="icon"
           onClick={() => toggleWeapon(weapon.id)}
           className="relative size-10 rounded shadow-[0_0_0_1px_rgba(0,0,0,0.08)] bg-muted/30 flex-shrink-0 overflow-hidden bg-[url(/images/item-frame-bg.png)] bg-cover bg-center cursor-pointer">
           {(() => { const s = weaponImageSrc(weapon.id); if (!s) return <span className="absolute inset-0 flex items-center justify-center text-lg font-semibold text-white/40">{weapon.name?.charAt(0) ?? '?'}</span>; return <Image src={s} alt={weaponName} fill className="object-cover z-10" unoptimized /> })()}
@@ -286,7 +288,7 @@ const WeaponRow = memo(function WeaponRow({
             className="absolute -inset-x-px bottom-0 z-20 w-[calc(100%+2px)] max-w-none object-cover object-bottom pointer-events-none"
             unoptimized
           />
-        </button>
+        </Button>
         <span
           className={cn(
             'font-medium min-w-0 truncate w-28 flex-shrink-0',

--- a/src/components/essence/dungeon-card.tsx
+++ b/src/components/essence/dungeon-card.tsx
@@ -109,6 +109,7 @@ const WeaponThumbnail = memo(function WeaponThumbnail({
 }: ThumbProps) {
   const t = useTranslations()
   const enableTooltip = useEssenceSettingsStore((s) => s.enableTooltipPlans)
+  const toggleWeapon = useMatrixStore((s) => s.toggleWeapon)
   const [open, setOpen] = useState(false)
   const triggerRef = useCloseOnScroll(open, setOpen)
 
@@ -170,19 +171,29 @@ const WeaponThumbnail = memo(function WeaponThumbnail({
     e.preventDefault()
   }, [])
 
+  const handleToggle = useCallback(() => {
+    if (longPressTriggeredRef.current) {
+      longPressTriggeredRef.current = false
+      return
+    }
+    toggleWeapon(weapon.id)
+  }, [toggleWeapon, weapon.id])
+
   const weaponName = (weapon.id?.startsWith('custom-') || weapon.id?.startsWith('preview:')) ? weapon.name : (t(`weapons.${weapon.id}`) ?? weapon.name)
 
   const thumb = (
     <button
       type="button"
       ref={triggerRef}
+      onClick={handleToggle}
       onPointerDown={isMobile && enableTooltip ? handlePointerDown : undefined}
       onPointerMove={isMobile && enableTooltip ? handlePointerMove : undefined}
       onPointerUp={isMobile && enableTooltip ? handlePointerEnd : undefined}
       onPointerCancel={isMobile && enableTooltip ? handlePointerEnd : undefined}
       onContextMenu={isMobile && enableTooltip ? handleContextMenu : undefined}
       className={cn(
-        'relative w-16 h-16 rounded-md overflow-hidden cursor-default select-none',
+        'relative w-16 h-16 rounded-md overflow-hidden select-none',
+        isMobile && enableTooltip ? 'cursor-default' : 'cursor-pointer',
         'bg-[url(/images/item-frame-bg.png)] bg-cover bg-center',
         isMobile && enableTooltip && 'touch-manipulation',
         inRange && isSelected && 'shadow-[0_0_0_1px_rgba(251,191,36,0.5)]',
@@ -248,6 +259,7 @@ const WeaponRow = memo(function WeaponRow({
   onNoteChange,
 }: RowProps) {
   const t = useTranslations()
+  const toggleWeapon = useMatrixStore((s) => s.toggleWeapon)
   const weaponName = (weapon.id?.startsWith('custom-') || weapon.id?.startsWith('preview:')) ? weapon.name : (t(`weapons.${weapon.id}`) ?? weapon.name)
 
   return (
@@ -261,7 +273,10 @@ const WeaponRow = memo(function WeaponRow({
       )}
     >
       <div className="flex items-center gap-2 min-w-0 shrink-0">
-        <div className="relative size-10 rounded shadow-[0_0_0_1px_rgba(0,0,0,0.08)] bg-muted/30 flex-shrink-0 overflow-hidden bg-[url(/images/item-frame-bg.png)] bg-cover bg-center">
+        <button
+          type="button"
+          onClick={() => toggleWeapon(weapon.id)}
+          className="relative size-10 rounded shadow-[0_0_0_1px_rgba(0,0,0,0.08)] bg-muted/30 flex-shrink-0 overflow-hidden bg-[url(/images/item-frame-bg.png)] bg-cover bg-center cursor-pointer">
           {(() => { const s = weaponImageSrc(weapon.id); if (!s) return <span className="absolute inset-0 flex items-center justify-center text-lg font-semibold text-white/40">{weapon.name?.charAt(0) ?? '?'}</span>; return <Image src={s} alt={weaponName} fill className="object-cover z-10" unoptimized /> })()}
           <Image
             src={`/images/item-band-${weapon.rarity}.png`}
@@ -271,7 +286,7 @@ const WeaponRow = memo(function WeaponRow({
             className="absolute -inset-x-px bottom-0 z-20 w-[calc(100%+2px)] max-w-none object-cover object-bottom pointer-events-none"
             unoptimized
           />
-        </div>
+        </button>
         <span
           className={cn(
             'font-medium min-w-0 truncate w-28 flex-shrink-0',

--- a/src/components/essence/selected-weapons-strip.tsx
+++ b/src/components/essence/selected-weapons-strip.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { memo } from 'react'
+import { useTranslations } from 'next-intl'
+import Image from 'next/image'
+import { ChevronRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+import type { Weapon } from '@/types/matrix'
+
+export interface SelectedWeaponsStripProps {
+  selectedIds: string[]
+  weaponsMap: Map<string, Weapon>
+  onToggleWeapon: (id: string) => void
+  onViewAll?: () => void
+}
+
+export const SelectedWeaponsStrip = memo(function SelectedWeaponsStrip({
+  selectedIds,
+  weaponsMap,
+  onToggleWeapon,
+  onViewAll,
+}: SelectedWeaponsStripProps) {
+  const t = useTranslations()
+
+  if (selectedIds.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="flex-1 flex gap-1.5 overflow-x-auto pb-1 min-w-0">
+        {selectedIds.map((id) => {
+          const weapon = weaponsMap.get(id)
+          if (!weapon) return null
+          const wid = weapon.id
+          const isCustom = wid.startsWith('custom-') || wid.startsWith('preview:')
+          const imgSrc = isCustom ? undefined : `/images/weapon/${wid}.avif`
+          const displayName = isCustom ? weapon.name : (t(`weapons.${wid}`) ?? weapon.name)
+
+          return (
+            <Button
+              key={id}
+              variant="ghost"
+              size="xs"
+              onClick={() => onToggleWeapon(id)}
+              className="shrink-0 flex items-center gap-1 h-9 pr-1.5 pl-1 rounded-md border border-amber-400/30 bg-amber-400/[0.04] hover:bg-amber-400/10"
+            >
+              <div className="relative size-7 shrink-0 rounded overflow-hidden bg-[url(/images/item-frame-bg.png)] bg-cover bg-center">
+                {imgSrc ? (
+                  <Image
+                    src={imgSrc}
+                    alt={displayName}
+                    fill
+                    className="object-cover"
+                    unoptimized
+                  />
+                ) : (
+                  <span className="absolute inset-0 flex items-center justify-center text-xs font-bold text-white/40">
+                    {weapon.name?.charAt(0) ?? '?'}
+                  </span>
+                )}
+                <Image
+                  src={`/images/item-band-${weapon.rarity}.png`}
+                  alt=""
+                  width={100}
+                  height={6}
+                  className="absolute -inset-x-px bottom-0 z-10 w-[calc(100%+2px)] max-w-none object-cover object-bottom pointer-events-none"
+                  unoptimized
+                />
+              </div>
+              <span className="text-[11px] font-medium truncate max-w-14">
+                {displayName}
+              </span>
+            </Button>
+          )
+        })}
+      </div>
+      {onViewAll && (
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={onViewAll}
+          className="shrink-0 flex items-center gap-1 h-9 px-2 rounded-md border border-border text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          <span>{t('essence.selectedList')}</span>
+          <ChevronRight className="size-3" />
+        </Button>
+      )}
+    </div>
+  )
+})

--- a/src/components/essence/weapon-grid.tsx
+++ b/src/components/essence/weapon-grid.tsx
@@ -2,14 +2,13 @@
 
 import { memo, useMemo, useCallback, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
-import Image from 'next/image'
 import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { ChevronRight } from 'lucide-react'
 
 import { FilterChip } from '@/components/shared/filter-chip'
 import { WeaponCard } from './weapon-card'
+import { SelectedWeaponsStrip } from './selected-weapons-strip'
 import { weapons as staticWeapons } from '@/data/weapons'
 import { useMatrixStore } from '@/stores/useMatrixStore'
 import { useEssenceSettingsStore } from '@/stores/useEssenceSettingsStore'
@@ -51,87 +50,7 @@ function attrFiltersToSets(record: Record<string, string[]>): Record<AttrKey, Se
 }
 
 // ─── Selected Weapons Strip ────────────────────────────────────────────────
-
-interface SelectedWeaponsStripProps {
-  selectedIds: string[]
-  weaponsMap: Map<string, Weapon>
-  onToggleWeapon: (id: string) => void
-  onViewAll?: () => void
-}
-
-const SelectedWeaponsStrip = memo(function SelectedWeaponsStrip({
-  selectedIds,
-  weaponsMap,
-  onToggleWeapon,
-  onViewAll,
-}: SelectedWeaponsStripProps) {
-  const t = useTranslations()
-
-  if (selectedIds.length === 0) return null
-
-  return (
-    <div className="flex items-center gap-1.5">
-      <div className="flex-1 flex gap-1.5 overflow-x-auto pb-1 min-w-0">
-        {selectedIds.map((id) => {
-          const weapon = weaponsMap.get(id)
-          if (!weapon) return null
-          const wid = weapon.id
-          const isCustom = wid.startsWith('custom-') || wid.startsWith('preview:')
-          const imgSrc = isCustom ? undefined : `/images/weapon/${wid}.avif`
-          const displayName = isCustom ? weapon.name : (t(`weapons.${wid}`) ?? weapon.name)
-
-          return (
-            <button
-              key={id}
-              type="button"
-              onClick={() => onToggleWeapon(id)}
-              className="shrink-0 flex items-center gap-1 h-9 pr-1.5 pl-1 rounded-md border border-amber-400/30 bg-amber-400/[0.04] hover:bg-amber-400/10 transition-colors"
-            >
-              <div className="relative size-7 shrink-0 rounded overflow-hidden bg-[url(/images/item-frame-bg.png)] bg-cover bg-center">
-                {imgSrc ? (
-                  <Image
-                    src={imgSrc}
-                    alt={displayName}
-                    fill
-                    className="object-cover"
-                    unoptimized
-                  />
-                ) : (
-                  <span className="absolute inset-0 flex items-center justify-center text-xs font-bold text-white/40">
-                    {weapon.name?.charAt(0) ?? '?'}
-                  </span>
-                )}
-                <Image
-                  src={`/images/item-band-${weapon.rarity}.png`}
-                  alt=""
-                  width={100}
-                  height={6}
-                  className="absolute -inset-x-px bottom-0 z-10 w-[calc(100%+2px)] max-w-none object-cover object-bottom pointer-events-none"
-                  unoptimized
-                />
-              </div>
-              <span className="text-[11px] font-medium truncate max-w-14">
-                {displayName}
-              </span>
-            </button>
-          )
-        })}
-      </div>
-      {onViewAll && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          onClick={onViewAll}
-          className="shrink-0 flex items-center gap-1 h-9 px-2 rounded-md border border-border text-[11px] text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <span>{t('essence.selectedList')}</span>
-          <ChevronRight className="size-3" />
-        </Button>
-      )}
-    </div>
-  )
-})
+// Moved to ./selected-weapons-strip.tsx
 
 interface WeaponGridProps {
   onViewAll?: () => void

--- a/src/components/essence/weapon-grid.tsx
+++ b/src/components/essence/weapon-grid.tsx
@@ -2,9 +2,11 @@
 
 import { memo, useMemo, useCallback, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
+import Image from 'next/image'
 import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { ChevronRight } from 'lucide-react'
 
 import { FilterChip } from '@/components/shared/filter-chip'
 import { WeaponCard } from './weapon-card'
@@ -48,11 +50,99 @@ function attrFiltersToSets(record: Record<string, string[]>): Record<AttrKey, Se
   }
 }
 
-export const WeaponGrid = memo(function WeaponGrid() {
+// ─── Selected Weapons Strip ────────────────────────────────────────────────
+
+interface SelectedWeaponsStripProps {
+  selectedIds: string[]
+  weaponsMap: Map<string, Weapon>
+  onToggleWeapon: (id: string) => void
+  onViewAll?: () => void
+}
+
+const SelectedWeaponsStrip = memo(function SelectedWeaponsStrip({
+  selectedIds,
+  weaponsMap,
+  onToggleWeapon,
+  onViewAll,
+}: SelectedWeaponsStripProps) {
+  const t = useTranslations()
+
+  if (selectedIds.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="flex-1 flex gap-1.5 overflow-x-auto pb-1 min-w-0">
+        {selectedIds.map((id) => {
+          const weapon = weaponsMap.get(id)
+          if (!weapon) return null
+          const wid = weapon.id
+          const isCustom = wid.startsWith('custom-') || wid.startsWith('preview:')
+          const imgSrc = isCustom ? undefined : `/images/weapon/${wid}.avif`
+          const displayName = isCustom ? weapon.name : (t(`weapons.${wid}`) ?? weapon.name)
+
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onToggleWeapon(id)}
+              className="shrink-0 flex items-center gap-1 h-9 pr-1.5 pl-1 rounded-md border border-amber-400/30 bg-amber-400/[0.04] hover:bg-amber-400/10 transition-colors"
+            >
+              <div className="relative size-7 shrink-0 rounded overflow-hidden bg-[url(/images/item-frame-bg.png)] bg-cover bg-center">
+                {imgSrc ? (
+                  <Image
+                    src={imgSrc}
+                    alt={displayName}
+                    fill
+                    className="object-cover"
+                    unoptimized
+                  />
+                ) : (
+                  <span className="absolute inset-0 flex items-center justify-center text-xs font-bold text-white/40">
+                    {weapon.name?.charAt(0) ?? '?'}
+                  </span>
+                )}
+                <Image
+                  src={`/images/item-band-${weapon.rarity}.png`}
+                  alt=""
+                  width={100}
+                  height={6}
+                  className="absolute -inset-x-px bottom-0 z-10 w-[calc(100%+2px)] max-w-none object-cover object-bottom pointer-events-none"
+                  unoptimized
+                />
+              </div>
+              <span className="text-[11px] font-medium truncate max-w-14">
+                {displayName}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+      {onViewAll && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={onViewAll}
+          className="shrink-0 flex items-center gap-1 h-9 px-2 rounded-md border border-border text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <span>{t('essence.selectedList')}</span>
+          <ChevronRight className="size-3" />
+        </Button>
+      )}
+    </div>
+  )
+})
+
+interface WeaponGridProps {
+  onViewAll?: () => void
+}
+
+export const WeaponGrid = memo(function WeaponGrid({ onViewAll }: WeaponGridProps) {
   const t = useTranslations()
   const filterCollapsed = useEssenceSettingsStore((s) => s.weaponFilterCollapsed)
   const toggleFilterCollapsed = useEssenceSettingsStore((s) => s.toggleWeaponFilterCollapsed)
   const selectedWeaponIds = useMatrixStore((s) => s.selectedWeaponIds)
+  const toggleWeapon = useMatrixStore((s) => s.toggleWeapon)
 
   // Shared filter state (lifted to store so desktop/mobile instances stay in sync)
   const query = useMatrixStore((s) => s.weaponSearchQuery)
@@ -208,9 +298,24 @@ export const WeaponGrid = memo(function WeaponGrid() {
     setVisibleWeaponIds(visibleIds)
   }, [visibleIds, setVisibleWeaponIds])
 
+  // Build O(1) lookup map for selected weapon strip
+  const selectedWeaponsMap = useMemo(() => {
+    const map = new Map<string, Weapon>()
+    for (const w of allWeapons) map.set(w.id, w)
+    return map
+  }, [allWeapons])
+
   return (
     <div className="flex flex-col gap-3">
       <Input placeholder={t('essence.searchWeapon')} value={query} onChange={(e) => setQuery(e.target.value)} className="text-sm" />
+
+      {/* Selected weapons strip */}
+      <SelectedWeaponsStrip
+        selectedIds={selectedWeaponIds}
+        weaponsMap={selectedWeaponsMap}
+        onToggleWeapon={toggleWeapon}
+        onViewAll={onViewAll}
+      />
 
       {/* Attribute filter — collapsible */}
       <div>

--- a/src/components/shared/app-init-overlay.tsx
+++ b/src/components/shared/app-init-overlay.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { useAppInitStore } from '@/stores/useAppInitStore'
@@ -57,6 +57,13 @@ export function AppInitOverlay() {
     return () => clearTimeout(timer)
   }, [ready, hasCompleted, markCompleted])
 
+  // Built before early-return to satisfy Rules of Hooks.
+  const feedbackLinks = useMemo(() => [
+    { href: 'https://github.com/cmyyx/cep', label: t('feedback.github') },
+    { href: 'https://end.302200.xyz', label: t('feedback.forum') },
+    { href: 'https://qm.qq.com/q/Cjdo2aRikE', label: t('feedback.qqGroup') },
+  ], [t])
+
   // Never show again after first completion.
   if (hasCompleted) return null
 
@@ -111,7 +118,7 @@ export function AppInitOverlay() {
         </div>
 
         {/* Feedback channels */}
-        <GuardFeedback title={t('feedback.title')} />
+        <GuardFeedback title={t('feedback.title')} links={feedbackLinks} />
       </div>
     </div>
   )

--- a/src/components/shared/guard-layout.tsx
+++ b/src/components/shared/guard-layout.tsx
@@ -118,13 +118,16 @@ export function GuardOverlay({ children }: { children: ReactNode }) {
 interface GuardFeedbackProps {
   title?: string
   className?: string
+  /** When provided, overrides hardcoded labels with i18n-aware labels. */
+  links?: { href: string; label: string }[]
 }
 
-function FeedbackLine({ lang }: { lang: 'zh' | 'en' }) {
+function FeedbackLine({ lang, links }: { lang: 'zh' | 'en'; links?: { href: string; label: string }[] }) {
+  const channels = links ?? FEEDBACK_CHANNELS
   const labelKey = lang === 'zh' ? 'labelZh' : 'labelEn'
   return (
     <>
-      {FEEDBACK_CHANNELS.map((ch, i) => (
+      {channels.map((ch, i) => (
         <span key={ch.href}>
           {i > 0 && ' \u00B7 '}
           <a
@@ -134,7 +137,7 @@ function FeedbackLine({ lang }: { lang: 'zh' | 'en' }) {
             className="hover:underline"
             style={{ color: '#0a72ef', marginLeft: i > 0 ? undefined : 4 }}
           >
-            {ch[labelKey]}
+            {'label' in ch ? ch.label : (ch as FeedbackChannel)[labelKey]}
           </a>
         </span>
       ))}
@@ -142,7 +145,9 @@ function FeedbackLine({ lang }: { lang: 'zh' | 'en' }) {
   )
 }
 
-export function GuardFeedback({ title, className }: GuardFeedbackProps) {
+export function GuardFeedback({ title, className, links }: GuardFeedbackProps) {
+  const hasLinks = links && links.length > 0
+
   return (
     <div
       className={cn('text-xs text-muted-foreground m-0', className)}
@@ -150,7 +155,20 @@ export function GuardFeedback({ title, className }: GuardFeedbackProps) {
     >
       {title ? (
         <p className="m-0" style={{ margin: 0 }}>
-          {title}<br /><FeedbackLine lang="zh" />
+          {title}<br />
+          {hasLinks ? (
+            links!.map((ch, i) => (
+              <span key={ch.href}>
+                {i > 0 && ' \u00B7 '}
+                <a href={ch.href} target="_blank" rel="noopener" className="hover:underline"
+                  style={{ color: '#0a72ef', marginLeft: i > 0 ? undefined : 4 }}>
+                  {ch.label}
+                </a>
+              </span>
+            ))
+          ) : (
+            <FeedbackLine lang="zh" />
+          )}
         </p>
       ) : (
         <>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -432,8 +432,8 @@
     "weaponsTab": "Weapons",
     "plansTab": "Plans",
     "viewPlans": "View Plans",
-    "manageWeapons": "Manage",
-    "viewAllSelected": "View All",
+    "manageWeapons": "Select Weapons",
+    "selectedList": "Selected List",
     "notePlaceholder": "Click to add note"
   },
   "essenceSettings": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -36,12 +36,7 @@
     "terms": "Terms of Service"
   },
   "app": {
-    "name": "CEP Endfield Planner (formerly Endfield Essence Planner)",
-    "phase": {
-      "splash": "INITIALIZING",
-      "tracking": "LOADING MODULES",
-      "ready": "READY"
-    }
+    "name": "CEP Endfield Planner (formerly Endfield Essence Planner)"
   },
   "auth": {
     "usernameOrEmail": "Username / Email",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -432,8 +432,8 @@
     "weaponsTab": "武器選択",
     "plansTab": "案内",
     "viewPlans": "案を見る",
-    "manageWeapons": "武器管理",
-    "viewAllSelected": "全て表示",
+    "manageWeapons": "武器選択",
+    "selectedList": "選択リスト",
     "notePlaceholder": "タップしてメモ追加"
   },
   "essenceSettings": {

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -36,12 +36,7 @@
     "terms": "利用規約"
   },
   "app": {
-    "name": "CEP エンドフィールドプランナー（旧終末地基質プランナー）",
-    "phase": {
-      "splash": "INITIALIZING",
-      "tracking": "LOADING MODULES",
-      "ready": "READY"
-    }
+    "name": "CEP エンドフィールドプランナー（旧終末地基質プランナー）"
   },
   "auth": {
     "usernameOrEmail": "ユーザー名 / メール",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -236,8 +236,8 @@
     "weaponsTab": "武器选择",
     "plansTab": "方案推荐",
     "viewPlans": "查看方案",
-    "manageWeapons": "管理武器",
-    "viewAllSelected": "查看全部",
+    "manageWeapons": "选择武器",
+    "selectedList": "已选清单",
     "notePlaceholder": "点击添加备注"
   },
   "essenceSettings": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -36,12 +36,7 @@
     "terms": "服务条款"
   },
   "app": {
-    "name": "CEP 终末地规划器（原终末地基质规划器）",
-    "phase": {
-      "splash": "INITIALIZING",
-      "tracking": "LOADING MODULES",
-      "ready": "READY"
-    }
+    "name": "CEP 终末地规划器（原终末地基质规划器）"
   },
   "auth": {
     "required": "此项为必填",

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -432,8 +432,8 @@
     "weaponsTab": "武器選擇",
     "plansTab": "方案推薦",
     "viewPlans": "檢視方案",
-    "manageWeapons": "管理武器",
-    "viewAllSelected": "檢視全部",
+    "manageWeapons": "選擇武器",
+    "selectedList": "已選清單",
     "notePlaceholder": "點擊添加備註"
   },
   "essenceSettings": {

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -36,12 +36,7 @@
     "terms": "服務條款"
   },
   "app": {
-    "name": "CEP 終末地規劃器（原終末地基質規劃器）",
-    "phase": {
-      "splash": "INITIALIZING",
-      "tracking": "LOADING MODULES",
-      "ready": "READY"
-    }
+    "name": "CEP 終末地規劃器（原終末地基質規劃器）"
   },
   "auth": {
     "usernameOrEmail": "使用者名稱 / 信箱",


### PR DESCRIPTION
1. 更新多语言文案，替换原有管理/全看按钮文本
2. 新增顶部已选武器快速选择栏，支持点击移除武器
3. 重构武器选择交互，点击武器卡片/行即可切换选中状态
4. 重构移动端布局，将全看弹窗适配桌面右侧面板
5. 优化移动端底部操作栏逻辑，调整按钮样式与功能

## Summary by Sourcery

改进精华规划器在桌面端和移动端视图中的武器选择体验（UX）。

新功能：
- 在武器网格上方新增一条水平的“已选武器”条，可快速移除武器并跳转到完整的已选列表。
- 引入统一的“已选武器”面板：在桌面端作为右侧侧边栏显示，在移动端作为底部抽屉显示。

优化改进：
- 使武器缩略图和列表行在点击时即可直接切换选择状态，简化选择流程。
- 调整移动端底部操作栏，增加专门的已选列表入口，并提供在武器与方案之间更清晰的导航。
- 更新与精华相关的界面文案，在各个本地化语言中使用新的标签来管理和查看已选武器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve essence planner weapon selection UX across desktop and mobile views.

New Features:
- Add a horizontal selected-weapons strip above the weapon grid with quick removal and navigation to the full selected list.
- Introduce a unified selected-weapons sheet that appears as a right-side panel on desktop and a bottom sheet on mobile.

Enhancements:
- Make weapon thumbnails and rows toggle selection directly when clicked, simplifying the selection flow.
- Adjust the mobile bottom action bar to expose a dedicated selected list entry point and clearer navigation between weapons and plans.
- Update essence-related UI copy to use new labels for managing and viewing selected weapons across locales.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增“已选清单”条目，支持在武器网格中一键打开已选列表（桌面侧抽屉、移动底部弹层）
  * 移动端底部工具栏新增“已选清单”按钮，便捷访问已选武器

* **界面调整**
  * 武器缩略图与列表项支持直接点击切换选中状态，交互更直观
  * 更新武器管理相关文案（“管理武器”→“选择武器”，新增“已选清单”文本，移除“查看全部”）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->