### PR TITLE
feat: 增加云端同步时武器ID解析功能，确保本地数据与云端一致

### DIFF
--- a/src/app/[locale]/account/page.tsx
+++ b/src/app/[locale]/account/page.tsx
@@ -34,7 +34,7 @@ function resolveCloudWeaponIds(raw: Record<string, unknown>): void {
     const ep = raw.essencePlanner as Record<string, unknown> | undefined
     if (ep) {
       if (Array.isArray(ep.selectedWeaponIds)) {
-        ep.selectedWeaponIds = (ep.selectedWeaponIds as string[]).map(resolveWeaponId)
+        ep.selectedWeaponIds = ep.selectedWeaponIds.filter((v): v is string => typeof v === 'string').map(resolveWeaponId)
       }
       if (ep.dungeonS1Selections) {
         ep.dungeonS1Selections = resolveS1Selections(ep.dungeonS1Selections as Record<string, string[]>)
@@ -103,7 +103,7 @@ function collectLocalData(): Record<string, unknown> {
     return _cachedLocalData.data
   }
   const data: Record<string, unknown> = {}
-  try { const r = localStorage.getItem('matrix-session'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; const ids: string[] = Array.isArray(s.selectedWeaponIds) ? s.selectedWeaponIds : []; data.essencePlanner = { selectedWeaponIds: ids.map(resolveWeaponId), dungeonS1Selections: resolveS1Selections((s.dungeonS1Selections ?? {}) as Record<string, string[]>) } } } catch {}
+  try { const r = localStorage.getItem('matrix-session'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; const ids = (Array.isArray(s.selectedWeaponIds) ? s.selectedWeaponIds : []).filter((v: unknown): v is string => typeof v === 'string'); data.essencePlanner = { selectedWeaponIds: ids.map(resolveWeaponId), dungeonS1Selections: resolveS1Selections((s.dungeonS1Selections ?? {}) as Record<string, string[]>) } } } catch {}
   try { const r = localStorage.getItem('essence-settings'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; data.essenceSettings = { weaponOwnership: resolveWeaponIdKeys((s.weaponOwnership ?? {}) as Record<string, unknown>), essenceStatus: resolveWeaponIdKeys((s.essenceStatus ?? {}) as Record<string, unknown>), weaponNotes: resolveWeaponIdKeys((s.weaponNotes ?? {}) as Record<string, unknown>), customWeapons: s.customWeapons ?? [], flags: Object.fromEntries(['hideEssenceOwnedWeaponsList','hideEssenceOwnedWeaponsPlans','hideUnownedWeaponsList','hideUnownedWeaponsPlans','hideFourStarWeaponsList','hideFourStarWeaponsPlans','enableOwnershipEditList','enableOwnershipEditPlans','enableNotesList','enableNotesPlans','keepUpVisibleList','keepUpVisiblePlans','onlyHideWhenBothOwned'].map(k=>[k,s[k]??false])), regionFirst: s.regionFirst??null, regionSecond: s.regionSecond??null } } } catch {}
   try { const r = localStorage.getItem('refinement-session'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; data.refinementPlanner = { selectedEquipId: s.selectedEquipId ?? null } } } catch {}
   _cachedLocalData = { data, ts: Date.now() }

--- a/src/app/[locale]/account/page.tsx
+++ b/src/app/[locale]/account/page.tsx
@@ -22,8 +22,34 @@ import { cn, maskEmail, isValidEmail, formatTime } from '@/lib/utils'
 import { SyncConflictDialog } from '@/components/shared/sync-conflict-dialog'
 import { equipById } from '@/data/equips'
 import { redeemCodeApi } from '@/lib/api'
+import { resolveWeaponId, resolveWeaponIdKeys, resolveS1Selections } from '@/lib/resolve-weapon-id'
 
 // ─── Sync ────────────────────────────────────────────────────
+
+/** Resolve stale preview:* weapon IDs in a cloud sync payload in-place.
+ *  Mutates the raw object so all downstream inline localStorage writes
+ *  and store updates automatically use resolved game IDs. */
+function resolveCloudWeaponIds(raw: Record<string, unknown>): void {
+  try {
+    const ep = raw.essencePlanner as Record<string, unknown> | undefined
+    if (ep) {
+      if (Array.isArray(ep.selectedWeaponIds)) {
+        ep.selectedWeaponIds = (ep.selectedWeaponIds as string[]).map(resolveWeaponId)
+      }
+      if (ep.dungeonS1Selections) {
+        ep.dungeonS1Selections = resolveS1Selections(ep.dungeonS1Selections as Record<string, string[]>)
+      }
+    }
+  } catch { /* best-effort */ }
+  try {
+    const es = raw.essenceSettings as Record<string, unknown> | undefined
+    if (es) {
+      if (es.weaponOwnership) es.weaponOwnership = resolveWeaponIdKeys(es.weaponOwnership as Record<string, unknown>)
+      if (es.essenceStatus) es.essenceStatus = resolveWeaponIdKeys(es.essenceStatus as Record<string, unknown>)
+      if (es.weaponNotes) es.weaponNotes = resolveWeaponIdKeys(es.weaponNotes as Record<string, unknown>)
+    }
+  } catch { /* best-effort */ }
+}
 
 /** Module-level cache for collectLocalData to avoid redundant
  *  localStorage parsing when called multiple times in quick succession
@@ -77,8 +103,8 @@ function collectLocalData(): Record<string, unknown> {
     return _cachedLocalData.data
   }
   const data: Record<string, unknown> = {}
-  try { const r = localStorage.getItem('matrix-session'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; data.essencePlanner = { selectedWeaponIds: s.selectedWeaponIds ?? [], dungeonS1Selections: s.dungeonS1Selections ?? {} } } } catch {}
-  try { const r = localStorage.getItem('essence-settings'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; data.essenceSettings = { weaponOwnership: s.weaponOwnership ?? {}, essenceStatus: s.essenceStatus ?? {}, weaponNotes: s.weaponNotes ?? {}, customWeapons: s.customWeapons ?? [], flags: Object.fromEntries(['hideEssenceOwnedWeaponsList','hideEssenceOwnedWeaponsPlans','hideUnownedWeaponsList','hideUnownedWeaponsPlans','hideFourStarWeaponsList','hideFourStarWeaponsPlans','enableOwnershipEditList','enableOwnershipEditPlans','enableNotesList','enableNotesPlans','keepUpVisibleList','keepUpVisiblePlans','onlyHideWhenBothOwned'].map(k=>[k,s[k]??false])), regionFirst: s.regionFirst??null, regionSecond: s.regionSecond??null } } } catch {}
+  try { const r = localStorage.getItem('matrix-session'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; const ids: string[] = Array.isArray(s.selectedWeaponIds) ? s.selectedWeaponIds : []; data.essencePlanner = { selectedWeaponIds: ids.map(resolveWeaponId), dungeonS1Selections: resolveS1Selections((s.dungeonS1Selections ?? {}) as Record<string, string[]>) } } } catch {}
+  try { const r = localStorage.getItem('essence-settings'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; data.essenceSettings = { weaponOwnership: resolveWeaponIdKeys((s.weaponOwnership ?? {}) as Record<string, unknown>), essenceStatus: resolveWeaponIdKeys((s.essenceStatus ?? {}) as Record<string, unknown>), weaponNotes: resolveWeaponIdKeys((s.weaponNotes ?? {}) as Record<string, unknown>), customWeapons: s.customWeapons ?? [], flags: Object.fromEntries(['hideEssenceOwnedWeaponsList','hideEssenceOwnedWeaponsPlans','hideUnownedWeaponsList','hideUnownedWeaponsPlans','hideFourStarWeaponsList','hideFourStarWeaponsPlans','enableOwnershipEditList','enableOwnershipEditPlans','enableNotesList','enableNotesPlans','keepUpVisibleList','keepUpVisiblePlans','onlyHideWhenBothOwned'].map(k=>[k,s[k]??false])), regionFirst: s.regionFirst??null, regionSecond: s.regionSecond??null } } } catch {}
   try { const r = localStorage.getItem('refinement-session'); if (r) { const p = JSON.parse(r); const s = p?.state ?? p; data.refinementPlanner = { selectedEquipId: s.selectedEquipId ?? null } } } catch {}
   _cachedLocalData = { data, ts: Date.now() }
   return data
@@ -189,6 +215,7 @@ export default function AccountPage() {
       const res = await getSyncDataApi()
       const raw = res.data as Record<string, unknown> | null
       if (raw) {
+        resolveCloudWeaponIds(raw)
         const localData = collectLocalData()
         if (hasExistingLocalData(localData) && syncDataDiffers(localData, raw)) {
           // If local hasn't changed since last sync, auto-apply cloud silently
@@ -392,6 +419,8 @@ export default function AccountPage() {
   }, [])
 
   const applyCloudDataToLocal = (cloudRaw: Record<string, unknown>) => {
+    // Resolve stale preview: IDs before writing to localStorage.
+    resolveCloudWeaponIds(cloudRaw)
     try {
       const ep = cloudRaw.essencePlanner as Record<string, unknown> | undefined
       if (ep) {
@@ -433,6 +462,7 @@ export default function AccountPage() {
       const latest = await getSyncDataApi()
       const localData = collectLocalData()
       const cloudRaw = latest.data as Record<string, unknown> | null
+      if (cloudRaw) resolveCloudWeaponIds(cloudRaw)
       const localRows = buildSummaryRows(localData)
       const cloudRows = cloudRaw
         ? buildSummaryRows(cloudRaw)
@@ -607,6 +637,7 @@ export default function AccountPage() {
     if (!cloudData?.data || !cloudVersion || cloudVersion <= 0 || conflict) return
     const localData = collectLocalData()
     const cloudRaw = cloudData.data as Record<string, unknown>
+    resolveCloudWeaponIds(cloudRaw)
     if (hasExistingLocalData(localData) && syncDataDiffers(localData, cloudRaw)) {
       const lastSig = getLastSyncSignature()
       if (lastSig !== null && computeSyncSignature(localData) === lastSig) {

--- a/src/hooks/useAutoSync.ts
+++ b/src/hooks/useAutoSync.ts
@@ -6,6 +6,7 @@ import { useMatrixStore } from '@/stores/useMatrixStore'
 import { useRefinementStore } from '@/stores/useRefinementStore'
 import { useEssenceSettingsStore } from '@/stores/useEssenceSettingsStore'
 import { getSyncDataApi, postSyncDataApi, getTokens } from '@/lib/api'
+import { resolveWeaponId, resolveWeaponIdKeys, resolveS1Selections } from '@/lib/resolve-weapon-id'
 
 import { regionI18nKey } from '@/data/region-i18n'
 
@@ -39,9 +40,11 @@ function syncStoresFromCloudPayload(raw: Record<string, unknown>) {
   try {
     const ep = raw.essencePlanner as Record<string, unknown> | undefined
     if (ep) {
+      const rawIds: string[] = Array.isArray(ep.selectedWeaponIds) ? ep.selectedWeaponIds.filter((v): v is string => typeof v === 'string') : []
+      const rawS1: Record<string, string[]> = (ep.dungeonS1Selections ?? {}) as Record<string, string[]>
       useMatrixStore.setState({
-        selectedWeaponIds: (Array.isArray(ep.selectedWeaponIds) ? ep.selectedWeaponIds : []) as string[],
-        dungeonS1Selections: (ep.dungeonS1Selections ?? {}) as Record<string, string[]>,
+        selectedWeaponIds: rawIds.map(resolveWeaponId),
+        dungeonS1Selections: resolveS1Selections(rawS1),
         plansStale: true,
       })
       // Recompute plans immediately after applying cloud data. Without this,
@@ -57,9 +60,9 @@ function syncStoresFromCloudPayload(raw: Record<string, unknown>) {
     const es = raw.essenceSettings as Record<string, unknown> | undefined
     if (es) {
       const next: Record<string, unknown> = {}
-      if (es.weaponOwnership) next.weaponOwnership = es.weaponOwnership
-      if (es.essenceStatus) next.essenceStatus = es.essenceStatus
-      if (es.weaponNotes) next.weaponNotes = es.weaponNotes
+      if (es.weaponOwnership) next.weaponOwnership = resolveWeaponIdKeys(es.weaponOwnership as Record<string, unknown>)
+      if (es.essenceStatus) next.essenceStatus = resolveWeaponIdKeys(es.essenceStatus as Record<string, unknown>)
+      if (es.weaponNotes) next.weaponNotes = resolveWeaponIdKeys(es.weaponNotes as Record<string, unknown>)
       if (Array.isArray(es.customWeapons)) next.customWeapons = es.customWeapons
       if (es.flags) Object.assign(next, es.flags)
       if (es.regionFirst !== undefined) next.regionFirst = es.regionFirst

--- a/src/lib/resolve-weapon-id.ts
+++ b/src/lib/resolve-weapon-id.ts
@@ -38,8 +38,9 @@ export function resolveS1Selections(
   s1: Record<string, string[]>,
 ): Record<string, string[]> {
   if (!s1 || typeof s1 !== 'object') return {}
-  const result: Record<string, string[]> = {}
+  const result = Object.create(null) as Record<string, string[]>
   for (const [key, ids] of Object.entries(s1)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
     if (Array.isArray(ids)) {
       result[key] = ids.map((id) => (typeof id === 'string' ? resolveWeaponId(id) : id)).filter((v): v is string => typeof v === 'string')
     }

--- a/src/lib/resolve-weapon-id.ts
+++ b/src/lib/resolve-weapon-id.ts
@@ -30,9 +30,23 @@ export function resolveWeaponId(id: string): string {
 }
 
 /**
- * Resolve all keys in a Record that may contain preview-IDs.
- * If multiple preview keys resolve to the same game ID, last one wins.
+ * Resolve weapon IDs in a dungeonS1Selections structure
+ * (Record<planKey, weaponId[]>). Returns a new object with all
+ * weapon IDs resolved from preview: to their current game IDs.
  */
+export function resolveS1Selections(
+  s1: Record<string, string[]>,
+): Record<string, string[]> {
+  if (!s1 || typeof s1 !== 'object') return {}
+  const result: Record<string, string[]> = {}
+  for (const [key, ids] of Object.entries(s1)) {
+    if (Array.isArray(ids)) {
+      result[key] = ids.map((id) => (typeof id === 'string' ? resolveWeaponId(id) : id)).filter((v): v is string => typeof v === 'string')
+    }
+  }
+  return result
+}
+
 export function resolveWeaponIdKeys<V>(record: Record<string, V>): Record<string, V> {
   let needsResolve = false
   for (const key of Object.keys(record)) {


### PR DESCRIPTION
## Summary by Sourcery

在使用本地存储和云端同步负载中的武器 ID 之前，先将其规范化为当前游戏使用的 ID，从而确保本地精华规划器/设置与云端保持一致。

新功能：
- 使用共享的解析器工具，将本地存储和云同步负载中的武器 ID 和地城 S1 选项进行规范化，以处理预览 ID。

增强内容：
- 为地城 S1 选择结构新增解析器，并在自动同步和本地数据收集期间，对精华设置应用武器 ID 键解析，防止状态和存储中残留过期 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure weapon IDs from local storage and cloud sync payloads are normalized to current game IDs before use, keeping local essence planner/settings consistent with the cloud.

New Features:
- Normalize weapon IDs and dungeon S1 selections from both local storage and cloud sync payloads using shared resolver utilities to handle preview IDs.

Enhancements:
- Add a resolver for dungeon S1 selection structures and apply weapon ID key resolution to essence settings during auto-sync and local data collection to prevent stale IDs in state and storage.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了云端数据同步时的武器ID解析逻辑，确保同步、冲突处理及本地数据写入过程中武器相关信息的一致性和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->