### PR TITLE
feat: 添加图片缓存版本号机制以解决缓存问题

### DIFF
--- a/scripts/generate-version.mjs
+++ b/scripts/generate-version.mjs
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process"
-import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from "node:fs"
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs"
 import { resolve, dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import { createHash } from "node:crypto"
@@ -61,28 +61,35 @@ function getSemver() {
 
 // 计算 public/images/ 目录的内容 hash 作为图片缓存版本号
 // 任何图片文件的新增/修改/删除都会改变此值，用于绕过浏览器旧缓存
-// 读取失败时 fallback 到 buildTime 的 hash，确保总有值
+// 使用文件内容（而非 mtime）哈希，确保 CI/新 clone 环境下版本号稳定
+// 读取失败时使用空内容 hash 作为确定性回退，避免每次构建产生不同版本号
 function getImageCacheVersion() {
   const imagesDir = resolve(root, "public", "images")
   try {
-    const entries = []
+    const hash = createHash("sha256")
     const walk = (dir) => {
-      for (const ent of readdirSync(dir, { withFileTypes: true })) {
+      const files = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+        a.name.localeCompare(b.name)
+      )
+      for (const ent of files) {
         const full = resolve(dir, ent.name)
         if (ent.isDirectory()) {
           walk(full)
         } else if (ent.isFile()) {
           const rel = full.slice(imagesDir.length).replace(/\\/g, "/")
-          const mtime = statSync(full).mtimeMs
-          entries.push(`${rel}:${mtime}`)
+          hash.update(rel)
+          hash.update(readFileSync(full))
         }
       }
     }
     walk(imagesDir)
-    entries.sort()
-    return createHash("sha256").update(entries.join("\n")).digest("hex").slice(0, 8)
-  } catch {
-    return createHash("sha256").update(new Date().toISOString()).digest("hex").slice(0, 8)
+    return hash.digest("hex").slice(0, 8)
+  } catch (err) {
+    console.warn(
+      "[generate-version] 读取 public/images 失败，使用空内容 hash 作为图片缓存版本号：",
+      err?.message ?? err
+    )
+    return createHash("sha256").update("").digest("hex").slice(0, 8)
   }
 }
 

--- a/scripts/generate-version.mjs
+++ b/scripts/generate-version.mjs
@@ -1,7 +1,8 @@
 import { execSync } from "node:child_process"
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs"
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from "node:fs"
 import { resolve, dirname } from "node:path"
 import { fileURLToPath } from "node:url"
+import { createHash } from "node:crypto"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, "..")
@@ -58,6 +59,33 @@ function getSemver() {
   return pkg.version || "0.0.0"
 }
 
+// 计算 public/images/ 目录的内容 hash 作为图片缓存版本号
+// 任何图片文件的新增/修改/删除都会改变此值，用于绕过浏览器旧缓存
+// 读取失败时 fallback 到 buildTime 的 hash，确保总有值
+function getImageCacheVersion() {
+  const imagesDir = resolve(root, "public", "images")
+  try {
+    const entries = []
+    const walk = (dir) => {
+      for (const ent of readdirSync(dir, { withFileTypes: true })) {
+        const full = resolve(dir, ent.name)
+        if (ent.isDirectory()) {
+          walk(full)
+        } else if (ent.isFile()) {
+          const rel = full.slice(imagesDir.length).replace(/\\/g, "/")
+          const mtime = statSync(full).mtimeMs
+          entries.push(`${rel}:${mtime}`)
+        }
+      }
+    }
+    walk(imagesDir)
+    entries.sort()
+    return createHash("sha256").update(entries.join("\n")).digest("hex").slice(0, 8)
+  } catch {
+    return createHash("sha256").update(new Date().toISOString()).digest("hex").slice(0, 8)
+  }
+}
+
 const semver = getSemver()
 const commitHash = git("rev-parse --short HEAD") || "unknown"
 const count = Number(git("rev-list --count HEAD")) || 0
@@ -71,6 +99,7 @@ const version = {
   buildTime: new Date().toISOString(),
   version: derivedVersion,
   forceUpgradeSerial: getForceUpgradeSerial(),
+  imageCacheVersion: getImageCacheVersion(),
 }
 
 const outPath = resolve(root, "public", "version.json")

--- a/src/app/[locale]/editor/page.tsx
+++ b/src/app/[locale]/editor/page.tsx
@@ -16,6 +16,7 @@ import { EditorMaterialsTab } from '@/components/editor/editor-materials-tab'
 import { EditorGuideTab } from '@/components/editor/editor-guide-tab'
 import { EditorAttributionsTab } from '@/components/editor/editor-attributions-tab'
 import { Plus, Download, Upload, Trash2, Lock, GitFork } from 'lucide-react'
+import { withImageCacheVersion } from '@/lib/image-url'
 
 const TABS: { key: EditorTab; labelKey: string }[] = [
   { key: 'basic', labelKey: 'editor.tabBasic' },
@@ -210,7 +211,7 @@ export default function EditorPage() {
                     <div className="w-7 h-7 rounded-full bg-muted shrink-0 flex items-center justify-center overflow-hidden shadow-[0px_0px_0px_1px_rgba(0,0,0,0.08)]">
                       {!failedImages.has(draft.id) && (
                         <Image
-                          src={`/images/characters/${draft.name}.avif`}
+                          src={withImageCacheVersion(`/images/characters/${draft.name}.avif`)}
                           alt={draft.name}
                           width={28}
                           height={28}

--- a/src/components/character-guide/character-detail.tsx
+++ b/src/components/character-guide/character-detail.tsx
@@ -12,6 +12,7 @@ import type { CharacterGuideData, GuideEquipRow, TeamSlot, GuideEquipEntry, Team
 import { weapons } from '@/data/weapons'
 import { equips } from '@/data/equips'
 import { MATERIAL_NAMES } from '@/data/material-names'
+import { withImageCacheVersion } from '@/lib/image-url'
 
 // Runtime name→imageId maps built from authoritative data sources (no JSON maintenance).
 // Exclude non-standard IDs (preview:, custom-, data:) that would produce invalid image URLs.
@@ -29,21 +30,21 @@ type ViewMode = 'info' | 'guide'
 
 function getWeaponImageSrc(name: string): string | null {
   const id = weaponNameToImageId.get(name)
-  return id ? `/images/weapon/${id}.avif` : null
+  return id ? withImageCacheVersion(`/images/weapon/${id}.avif`) : null
 }
 
 function getEquipImageSrc(name: string): string | null {
   // Exact match
   const id = equipNameToId.get(name)
-  if (id) return `/images/equip/${id}.avif`
+  if (id) return withImageCacheVersion(`/images/equip/${id}.avif`)
   // Try matching base name (strip ·壹型, ·贰型, ·叁型 suffix)
   const baseName = name.replace(/[·‧]壹型|[·‧]贰型|[·‧]叁型/g, '').trim()
   const baseId = equipNameToId.get(baseName)
-  if (baseId) return `/images/equip/${baseId}.avif`
+  if (baseId) return withImageCacheVersion(`/images/equip/${baseId}.avif`)
   // Try fuzzy: find any key that contains the base name
   for (const [key, val] of equipNameToId) {
     if (key.includes(baseName) || baseName.includes(key)) {
-      return `/images/equip/${val}.avif`
+      return withImageCacheVersion(`/images/equip/${val}.avif`)
     }
   }
   return null
@@ -53,7 +54,7 @@ function getItemImageSrc(name: string): string | null {
   const cleanName = stripMaterialQuantity(name)
   if (!cleanName || !MATERIAL_NAMES.has(cleanName)) return null
   // item images follow name→name.avif pattern
-  return `/images/item/${cleanName}.avif`
+  return withImageCacheVersion(`/images/item/${cleanName}.avif`)
 }
 
 // ---- Collapsible section ----
@@ -138,7 +139,7 @@ function GuideCard({
       {/* Rarity band */}
       {rarity && !bandFailed && (
         <Image
-          src={`/images/item-band-${rarity}.png`}
+          src={withImageCacheVersion(`/images/item-band-${rarity}.png`)}
           alt=""
           width={200}
           height={40}
@@ -278,7 +279,7 @@ function OptionDisplay({ option, isRecommended, isAlternative }: { option: TeamS
         <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center overflow-hidden shadow-[0px_0px_0px_1px_rgba(0,0,0,0.08)] relative">
           {!avatarFailed && (
             <Image
-              src={`/images/characters/${option.name}.avif`}
+              src={withImageCacheVersion(`/images/characters/${option.name}.avif`)}
               alt={option.name}
               fill
               unoptimized
@@ -376,7 +377,7 @@ export const CharacterDetail = memo(function CharacterDetail({
     )
   }
 
-  const cardPath = `/images/characters/${character.name}_card.avif`
+  const cardPath = withImageCacheVersion(`/images/characters/${character.name}_card.avif`)
 
   return (
     <div className="flex flex-col h-full overflow-y-scroll">
@@ -402,7 +403,7 @@ export const CharacterDetail = memo(function CharacterDetail({
           <div className="w-14 h-14 rounded-full bg-muted shrink-0 flex items-center justify-center overflow-hidden shadow-[0px_0px_0px_1px_rgba(0,0,0,0.08)] relative">
             {!avatarFailed && (
               <Image
-                src={`/images/characters/${character.name}.avif`}
+                src={withImageCacheVersion(`/images/characters/${character.name}.avif`)}
                 alt={character.name}
                 fill
                 unoptimized

--- a/src/components/character-guide/character-list.tsx
+++ b/src/components/character-guide/character-list.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { RarityStars } from './element-badge'
 import type { CharacterGuideData } from '@/types/character-guide'
+import { withImageCacheVersion } from '@/lib/image-url'
 
 interface CharacterListProps {
   characters: CharacterGuideData[]
@@ -161,7 +162,7 @@ export const CharacterList = memo(function CharacterList({
               <div className="w-9 h-9 rounded-full bg-muted shrink-0 flex items-center justify-center overflow-hidden shadow-[0px_0px_0px_1px_rgba(0,0,0,0.08)] relative">
                 {!failedImages.has(char.name) ? (
                   <Image
-                    src={`/images/characters/${char.name}.avif`}
+                    src={withImageCacheVersion(`/images/characters/${char.name}.avif`)}
                     alt={char.name}
                     fill
                     unoptimized

--- a/src/components/essence/dungeon-card.tsx
+++ b/src/components/essence/dungeon-card.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button'
 
 import { computeEffectiveS1 } from '@/lib/planner/s1-utils'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { withImageCacheVersion } from '@/lib/image-url'
 
 interface DungeonCardProps {
   plan: DungeonPlan
@@ -37,7 +38,7 @@ function weaponImageSrc(id?: string, iconId?: string): string | undefined {
   if (id.startsWith('data:')) return id
   // 优先使用 iconId（游戏原始资源映射，如 wpn_funnel_0008/0010 交叉指向）
   const imageId = iconId ?? id
-  return `/images/weapon/${imageId}.avif`
+  return withImageCacheVersion(`/images/weapon/${imageId}.avif`)
 }
 
 interface RowProps extends ThumbProps {
@@ -158,7 +159,7 @@ const WeaponThumbnail = memo(function WeaponThumbnail({
     >
       {(() => { const s = weaponImageSrc(weapon.id, weapon.iconId); if (!s) return <span className="absolute inset-0 flex items-center justify-center text-lg font-semibold text-white/40">{weapon.name?.charAt(0) ?? '?'}</span>; return <Image src={s} alt={weaponName} fill className="object-cover z-10" unoptimized /> })()}
       <Image
-        src={`/images/item-band-${weapon.rarity}.png`}
+        src={withImageCacheVersion(`/images/item-band-${weapon.rarity}.png`)}
         alt=""
         width={200}
         height={10}
@@ -234,7 +235,7 @@ const WeaponRow = memo(function WeaponRow({
           className="relative size-10 rounded shadow-[0_0_0_1px_rgba(0,0,0,0.08)] bg-muted/30 flex-shrink-0 overflow-hidden bg-[url(/images/item-frame-bg.png)] bg-cover bg-center cursor-pointer">
           {(() => { const s = weaponImageSrc(weapon.id); if (!s) return <span className="absolute inset-0 flex items-center justify-center text-lg font-semibold text-white/40">{weapon.name?.charAt(0) ?? '?'}</span>; return <Image src={s} alt={weaponName} fill className="object-cover z-10" unoptimized /> })()}
           <Image
-            src={`/images/item-band-${weapon.rarity}.png`}
+            src={withImageCacheVersion(`/images/item-band-${weapon.rarity}.png`)}
             alt=""
             width={200}
             height={8}

--- a/src/components/essence/selected-weapons-strip.tsx
+++ b/src/components/essence/selected-weapons-strip.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import { ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { withImageCacheVersion } from '@/lib/image-url'
 
 import type { Weapon } from '@/types/matrix'
 
@@ -35,7 +36,7 @@ export const SelectedWeaponsStrip = memo(function SelectedWeaponsStrip({
           const isCustom = wid.startsWith('custom-') || wid.startsWith('preview:')
           // 优先使用 iconId（游戏原始资源映射）
           const imageId = weapon.iconId ?? wid
-          const imgSrc = isCustom ? undefined : `/images/weapon/${imageId}.avif`
+          const imgSrc = isCustom ? undefined : withImageCacheVersion(`/images/weapon/${imageId}.avif`)
           const displayName = isCustom ? weapon.name : (t(`weapons.${wid}`) ?? weapon.name)
 
           return (
@@ -61,7 +62,7 @@ export const SelectedWeaponsStrip = memo(function SelectedWeaponsStrip({
                   </span>
                 )}
                 <Image
-                  src={`/images/item-band-${weapon.rarity}.png`}
+                  src={withImageCacheVersion(`/images/item-band-${weapon.rarity}.png`)}
                   alt=""
                   width={100}
                   height={6}

--- a/src/components/essence/weapon-card.tsx
+++ b/src/components/essence/weapon-card.tsx
@@ -10,6 +10,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Button } from '@/components/ui/button'
 import { Check } from 'lucide-react'
 import { useMobileLongPressTooltip } from '@/hooks/use-mobile-long-press-tooltip'
+import { withImageCacheVersion } from '@/lib/image-url'
 
 import type { Weapon } from '@/types/matrix'
 
@@ -58,7 +59,7 @@ export const WeaponCard = memo(function WeaponCard({
   const imageId = weapon.iconId ?? wid
   const imageSrc = (isCustom || isPreview) ? undefined : wid.startsWith('data:')
     ? wid
-    : `/images/weapon/${imageId}.avif`
+    : withImageCacheVersion(`/images/weapon/${imageId}.avif`)
   const displayName = (isCustom || isPreview) ? weapon.name : (t(`weapons.${wid}`) ?? weapon.name)
 
   const trigger = (
@@ -111,7 +112,7 @@ export const WeaponCard = memo(function WeaponCard({
               className="relative size-8 rounded-full bg-black/60 border border-white/35 shadow-md overflow-hidden"
             >
               <Image
-                src={`/images/characters/${char}.avif`}
+                src={withImageCacheVersion(`/images/characters/${char}.avif`)}
                 alt={char}
                 fill
                 className="object-cover"
@@ -124,7 +125,7 @@ export const WeaponCard = memo(function WeaponCard({
 
       {/* Rarity band image */}
       <Image
-        src={`/images/item-band-${weapon.rarity}.png`}
+        src={withImageCacheVersion(`/images/item-band-${weapon.rarity}.png`)}
         alt=""
         width={200}
         height={40}

--- a/src/components/refinement/equip-card.tsx
+++ b/src/components/refinement/equip-card.tsx
@@ -9,6 +9,7 @@ import { useRefinementStore } from '@/stores/useRefinementStore'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import { useMobileLongPressTooltip } from '@/hooks/use-mobile-long-press-tooltip'
+import { withImageCacheVersion } from '@/lib/image-url'
 import type { Equip } from '@/types/refinement'
 
 // Map Chinese equip types to i18n keys
@@ -78,7 +79,7 @@ export const EquipCard = memo(function EquipCard({
   const displayType = t(`equipTypes.${TYPE_TO_KEY[equip.type] ?? equip.type}`) ?? equip.type
   const displayMaterial = equip.material ? (t(`materials.${equip.material}`) ?? equip.material) : ''
   const imageSrc = equip.imageId
-    ? `/images/equip/${equip.imageId}.avif`
+    ? withImageCacheVersion(`/images/equip/${equip.imageId}.avif`)
     : ''
 
   return (
@@ -124,7 +125,7 @@ export const EquipCard = memo(function EquipCard({
 
         {/* Rarity band */}
         <Image
-          src={`/images/item-band-${equip.rarity}.png`}
+          src={withImageCacheVersion(`/images/item-band-${equip.rarity}.png`)}
           alt=""
           width={200}
           height={40}

--- a/src/components/refinement/refinement-panel.tsx
+++ b/src/components/refinement/refinement-panel.tsx
@@ -9,6 +9,7 @@ import { SlotRecommendationCard } from './slot-recommendation'
 import { useRefinementStore, useSelectedEquip, useRecommendations } from '@/stores/useRefinementStore'
 import { materialOptions } from '@/data/equips'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { withImageCacheVersion } from '@/lib/image-url'
 
 // Map Chinese equip types to i18n keys
 const TYPE_TO_KEY: Record<string, string> = {
@@ -76,7 +77,7 @@ export const RefinementPanel = memo(function RefinementPanel() {
               <div className={cn('relative shrink-0 rounded-lg border border-border overflow-hidden bg-[url(/images/item-frame-bg.png)] bg-cover bg-center', isMobile ? 'w-20 h-20' : 'w-24 h-24')}>
                 {selected.imageId && (
                   <Image
-                    src={`/images/equip/${selected.imageId}.avif`}
+                    src={withImageCacheVersion(`/images/equip/${selected.imageId}.avif`)}
                     alt={t(`equips.${selected.id}`) ?? selected.name}
                     fill
                     sizes={isMobile ? '80px' : '96px'}
@@ -85,7 +86,7 @@ export const RefinementPanel = memo(function RefinementPanel() {
                   />
                 )}
                 <Image
-                  src={`/images/item-band-${selected.rarity}.png`}
+                  src={withImageCacheVersion(`/images/item-band-${selected.rarity}.png`)}
                   alt=""
                   width={200}
                   height={40}

--- a/src/lib/image-url.test.ts
+++ b/src/lib/image-url.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const { mockVersionData } = vi.hoisted(() => ({
+  mockVersionData: { imageCacheVersion: 'abc12345' },
+}))
+
+vi.mock('@/generated/version-data', () => ({
+  versionData: mockVersionData,
+}))
+
+import { withImageCacheVersion } from './image-url'
+
+describe('withImageCacheVersion', () => {
+  it('appends ?v= when version is present', () => {
+    mockVersionData.imageCacheVersion = 'abc12345'
+    expect(withImageCacheVersion('/images/weapon/foo.avif')).toBe(
+      '/images/weapon/foo.avif?v=abc12345'
+    )
+  })
+
+  it('uses & separator when path already has query string', () => {
+    mockVersionData.imageCacheVersion = 'abc12345'
+    expect(
+      withImageCacheVersion('/images/weapon/foo.avif?size=small')
+    ).toBe('/images/weapon/foo.avif?size=small&v=abc12345')
+  })
+
+  it('returns path unchanged when version is empty', () => {
+    mockVersionData.imageCacheVersion = ''
+    expect(withImageCacheVersion('/images/weapon/foo.avif')).toBe(
+      '/images/weapon/foo.avif'
+    )
+  })
+
+  it('does not append separator when version is empty even if path has query', () => {
+    mockVersionData.imageCacheVersion = ''
+    expect(
+      withImageCacheVersion('/images/weapon/foo.avif?size=small')
+    ).toBe('/images/weapon/foo.avif?size=small')
+  })
+})

--- a/src/lib/image-url.ts
+++ b/src/lib/image-url.ts
@@ -1,0 +1,12 @@
+import { versionData } from '@/generated/version-data'
+
+const imageCacheVersion = versionData.imageCacheVersion
+
+/**
+ * 为图片 URL 附加内容版本号查询参数，用于绕过浏览器旧缓存。
+ * 版本号在构建时由 scripts/generate-version.mjs 基于 public/images/ 目录内容 hash 生成，
+ * 任何图片文件变动都会使版本号变化，从而产生新的 URL 绕过旧缓存。
+ */
+export function withImageCacheVersion(path: string): string {
+  return imageCacheVersion ? `${path}?v=${imageCacheVersion}` : path
+}

--- a/src/lib/image-url.ts
+++ b/src/lib/image-url.ts
@@ -1,12 +1,13 @@
 import { versionData } from '@/generated/version-data'
 
-const imageCacheVersion = versionData.imageCacheVersion
-
 /**
  * 为图片 URL 附加内容版本号查询参数，用于绕过浏览器旧缓存。
  * 版本号在构建时由 scripts/generate-version.mjs 基于 public/images/ 目录内容 hash 生成，
  * 任何图片文件变动都会使版本号变化，从而产生新的 URL 绕过旧缓存。
  */
 export function withImageCacheVersion(path: string): string {
-  return imageCacheVersion ? `${path}?v=${imageCacheVersion}` : path
+  const version = versionData.imageCacheVersion
+  if (!version) return path
+  const separator = path.includes('?') ? '&' : '?'
+  return `${path}${separator}v=${version}`
 }

--- a/src/stores/useBannerStore.ts
+++ b/src/stores/useBannerStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { withImageCacheVersion } from '@/lib/image-url'
 import { bannerSchedule, standardCharacters } from '@/data/banner-data'
 import { isCharacterOnBanner } from '@/lib/banner-utils'
 import type {
@@ -59,7 +60,7 @@ function normalizeSchedule(source: BannerSchedule): CharacterScheduleIndex {
 
     result[characterName] = {
       characterName, windows,
-      avatarSrc: `/images/characters/${characterName}.avif`,
+      avatarSrc: withImageCacheVersion(`/images/characters/${characterName}.avif`),
       period: mainPeriod, isStandard: false,
       offRateNote: entry.offRateNote,
     }
@@ -69,7 +70,7 @@ function normalizeSchedule(source: BannerSchedule): CharacterScheduleIndex {
     if (result[name]) continue
     result[name] = {
       characterName: name, windows: [],
-      avatarSrc: `/images/characters/${name}.avif`,
+      avatarSrc: withImageCacheVersion(`/images/characters/${name}.avif`),
       period: null, isStandard: true,
     }
   }

--- a/src/types/version.ts
+++ b/src/types/version.ts
@@ -5,4 +5,5 @@ export interface VersionInfo {
   buildTime: string
   version: string
   forceUpgradeSerial: number
+  imageCacheVersion: string
 }


### PR DESCRIPTION
新增脚本生成图片目录哈希作为缓存版本，为所有图片URL附加版本参数避免旧缓存影响，更新类型定义并替换所有硬编码图片路径

## Summary by Sourcery

引入构建时的图片缓存版本机制，并在整个应用中使用，以清除浏览器中过期的图片缓存。

新功能：
- 基于 `public/images` 目录内容的哈希生成图片缓存版本，并通过 `version.json` 和类型化的 `VersionInfo` 对外暴露。
- 添加一个辅助方法，将图片缓存版本作为查询参数附加到图片 URL 上，并在整个 UI 中用于角色、武器、装备、道具和乐队图片。

改进：
- 用集中式的辅助方法替换硬编码的图片路径，确保在角色攻略、精华视图、精炼 UI、卡池商店和编辑器中一致地生成带缓存清除参数的图片 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a build-time image cache versioning mechanism and apply it across the app to bust stale browser image caches.

New Features:
- Generate an image cache version based on the hash of the public/images directory contents and expose it via version.json and typed VersionInfo.
- Add a helper to append the image cache version as a query parameter to image URLs and use it throughout the UI for character, weapon, equip, item, and band images.

Enhancements:
- Replace hardcoded image paths with a centralized helper to ensure consistent cache-busted image URLs across character guides, essence views, refinement UI, banner store, and editor.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入图片缓存版本号：在构建时根据图片内容生成版本，并将其自动附加到图片 URL 上。
  * 多个页面的角色、武器、装备及相关素材图片加载已统一切换为带版本标记的地址。
* **Bug 修复**
  * 缓解图片更新后仍命中旧浏览器缓存导致显示不及时的问题。
* **测试**
  * 新增对图片 URL 版本拼接逻辑的单元测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->