### PR TITLE
feat(weapons): 新增四二式·肃阵、曜夜的首演 preview 武器

### DIFF
--- a/src/data/weapons.ts
+++ b/src/data/weapons.ts
@@ -2,6 +2,9 @@ import type { Weapon } from '@/types/matrix'
 
 export const weapons: Weapon[] = [
   // ===== 六星 =====
+  // --- preview：官方预告，游戏实装后由 `pnpm sync:update` 自动 promote 为正式 id ---
+  { id: 'preview:四二式·肃阵', name: '四二式·肃阵', rarity: 6, type: '施术单元', primaryStat: 'gat_passive_attr_wisd', elementalDamage: 'gat_passive_attr_usp', specialAbility: 'gst_passive_burst', chars: [], source: 'preview' },
+  { id: 'preview:曜夜的首演', name: '曜夜的首演', rarity: 6, type: '长柄武器', primaryStat: 'gat_passive_attr_will', elementalDamage: 'gat_passive_attr_heal', specialAbility: 'gst_passive_heal', chars: [], source: 'preview' },
   { id: 'wpn_claym_0017', iconId: 'wpn_claym_0017', name: '赤缨', rarity: 6, type: '双手剑', primaryStat: 'gat_passive_attr_str', elementalDamage: 'gat_passive_attr_atk', specialAbility: 'gst_passive_phyabn', chars: ['弭弗'], },
   { id: 'wpn_lance_0015', iconId: 'wpn_lance_0015', name: '镀红祝福', rarity: 6, type: '长柄武器', primaryStat: 'gat_passive_attr_agi', elementalDamage: 'gat_passive_attr_firedam', specialAbility: 'gst_passive_tacafter', chars: ['卡缪'], },
   { id: 'wpn_claym_0016', iconId: 'wpn_claym_0016', name: '幻想苦痛', rarity: 6, type: '双手剑', primaryStat: 'gat_passive_attr_str', elementalDamage: 'gat_passive_attr_physpell', specialAbility: 'gst_passive_tactic', chars: [], },


### PR DESCRIPTION
## 改动

在 `src/data/weapons.ts` 六星组顶部新增两条 preview 武器（路径 B：官方已预告、游戏未实装）：

| 武器 | 类型 | 主属性 | 元素伤害 | 特殊能力 |
|------|------|--------|----------|----------|
| 四二式·肃阵 | 施术单元 | 智识 | 终结技充能效率 | 迸发 |
| 曜夜的首演 | 长柄武器 | 意志 | 治疗效率 | 医疗 |

## 渲染行为

- preview 武器在武器网格中单独分组，排在自定义武器之后、banner UP 之前
- 卡片走首字占位 + preview 角标（preview 阶段无图标资源，设计如此）
- 可正常点选、加入方案、持久化

## promote 机制

游戏实装后执行 `pnpm sync:update`：
- 按 name 匹配，自动将 `preview:四二式·肃阵` 改名为正式 `wpn_*` id
- 移除 `source: 'preview'`，补全 `iconId`，保留 `chars`
- 用户已持久化的 preview 选择经 `resolveWeaponId` 自动迁移，不丢失

## 验证

- vitest 全量 293/293 通过（含 `weapons.test.ts` 6/6）
- `tsc --noEmit` 0 错误
- `eslint` 0 warning
- `check-i18n` / `check-images` 通过（preview 被各校验显式跳过）
- dev server 渲染确认 HTML 含两把武器名

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

新功能：
- 在武器数据中为六星武器“四二式·肃阵”和“曜夜的首演”加入预览条目，并标记为预览来源，以便后续推广使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce preview entries for the six-star weapons 四二式·肃阵 and 曜夜的首演 in the weapons data, marked as preview sources for later promotion.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增两条六星武器预告数据，包含名称、属性、类型及特殊能力等信息。
  * 预告武器将在正式实装后自动更新为正式数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->