### PR TITLE
Beta v1.4.2 fix

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,6 +49,9 @@
   --color-rarity-6-star: #ff7100;
   --color-rarity-5-star: #ffcc00;
 
+  /* Timeline status badge colors */
+  --color-status-future: #a78bfa;
+
   /* DESIGN.md radius scale */
   --radius-none: 0;
   --radius-micro: calc(var(--radius) * 0.3333);

--- a/src/components/banner-calendar/pool-info-strip.test.tsx
+++ b/src/components/banner-calendar/pool-info-strip.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { PoolInfoStrip } from './pool-info-strip'
+
+const mockT = (key: string) => key
+vi.mock('next-intl', () => ({
+  useTranslations: () => mockT,
+  useLocale: () => 'zh-CN',
+}))
+
+vi.mock('@/data/banner', () => ({
+  bannerEntries: [
+    {
+      id: '1.4-jue',
+      title: '「临渊望北」特许寻访',
+      subtitle: '诀',
+      description: 'test description',
+      imageUrl: '/images/banners/jue.webp',
+      officialUrl: '',
+      version: '1.4',
+      periodStart: '2026-07-16T12:00:00+08:00',
+      periodEnd: '2026-08-09T11:59:00+08:00',
+      featured: [{ name: '诀', period: 9 }],
+    },
+  ],
+}))
+
+describe('PoolInfoStrip', () => {
+  it('renders header text', () => {
+    const { container } = render(<PoolInfoStrip />)
+    expect(container.textContent).toContain('bannerCalendar.poolInfo')
+  })
+
+  it('renders banner title from entries', () => {
+    const { container } = render(<PoolInfoStrip />)
+    expect(container.textContent).toContain('「临渊望北」特许寻访')
+  })
+})

--- a/src/components/banner-calendar/pool-info-strip.test.tsx
+++ b/src/components/banner-calendar/pool-info-strip.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { PoolInfoStrip } from './pool-info-strip'
 
 const mockT = (key: string) => key
@@ -35,5 +35,34 @@ describe('PoolInfoStrip', () => {
   it('renders banner title from entries', () => {
     const { container } = render(<PoolInfoStrip />)
     expect(container.textContent).toContain('「临渊望北」特许寻访')
+  })
+
+  it('opens dialog when a banner visual is clicked', () => {
+    const { container } = render(<PoolInfoStrip />)
+    const bannerBtn = container.querySelector('button')
+    expect(bannerBtn).not.toBeNull()
+    fireEvent.click(bannerBtn!)
+    const dialogTitle = document.querySelector('[data-slot="dialog-title"]')
+    expect(dialogTitle).not.toBeNull()
+    expect(dialogTitle?.textContent).toBe('「临渊望北」特许寻访')
+  })
+
+  it('expands info card when info button is clicked', () => {
+    const { container } = render(<PoolInfoStrip />)
+    const bannerBtn = container.querySelector('button')
+    fireEvent.click(bannerBtn!)
+    const infoBtn = document.querySelector('[aria-label="bannerCalendar.poolInfo"]')
+    expect(infoBtn).not.toBeNull()
+    fireEvent.click(infoBtn!)
+    expect(document.body.textContent).toContain('bannerCalendar.poolDuration')
+  })
+
+  it('renders close button with accessible text', () => {
+    const { container } = render(<PoolInfoStrip />)
+    const bannerBtn = container.querySelector('button')
+    fireEvent.click(bannerBtn!)
+    const closeSpan = document.querySelector('span.sr-only')
+    expect(closeSpan).not.toBeNull()
+    expect(closeSpan?.textContent).toBe('common.close')
   })
 })

--- a/src/components/banner-calendar/pool-info-strip.test.tsx
+++ b/src/components/banner-calendar/pool-info-strip.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { cleanup, render, fireEvent, screen } from '@testing-library/react'
 import { PoolInfoStrip } from './pool-info-strip'
 
 const mockT = (key: string) => key
@@ -26,43 +26,42 @@ vi.mock('@/data/banner', () => ({
   ],
 }))
 
+afterEach(() => {
+  cleanup()
+})
+
 describe('PoolInfoStrip', () => {
   it('renders header text', () => {
-    const { container } = render(<PoolInfoStrip />)
-    expect(container.textContent).toContain('bannerCalendar.poolInfo')
+    render(<PoolInfoStrip />)
+    expect(screen.getByText('bannerCalendar.poolInfo')).toBeTruthy()
   })
 
   it('renders banner title from entries', () => {
-    const { container } = render(<PoolInfoStrip />)
-    expect(container.textContent).toContain('「临渊望北」特许寻访')
+    render(<PoolInfoStrip />)
+    expect(screen.getByRole('button', { name: /「临渊望北」特许寻访/ })).toBeTruthy()
   })
 
   it('opens dialog when a banner visual is clicked', () => {
-    const { container } = render(<PoolInfoStrip />)
-    const bannerBtn = container.querySelector('button')
-    expect(bannerBtn).not.toBeNull()
-    fireEvent.click(bannerBtn!)
-    const dialogTitle = document.querySelector('[data-slot="dialog-title"]')
-    expect(dialogTitle).not.toBeNull()
-    expect(dialogTitle?.textContent).toBe('「临渊望北」特许寻访')
+    render(<PoolInfoStrip />)
+    const bannerButton = screen.getByRole('button', { name: /「临渊望北」特许寻访/ })
+    fireEvent.click(bannerButton)
+    expect(screen.getByRole('dialog', { name: '「临渊望北」特许寻访' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: '「临渊望北」特许寻访' })).toBeTruthy()
   })
 
   it('expands info card when info button is clicked', () => {
-    const { container } = render(<PoolInfoStrip />)
-    const bannerBtn = container.querySelector('button')
-    fireEvent.click(bannerBtn!)
-    const infoBtn = document.querySelector('[aria-label="bannerCalendar.poolInfo"]')
-    expect(infoBtn).not.toBeNull()
-    fireEvent.click(infoBtn!)
-    expect(document.body.textContent).toContain('bannerCalendar.poolDuration')
+    render(<PoolInfoStrip />)
+    const bannerButton = screen.getByRole('button', { name: /「临渊望北」特许寻访/ })
+    fireEvent.click(bannerButton)
+    const infoButton = screen.getByLabelText('bannerCalendar.poolInfo')
+    fireEvent.click(infoButton)
+    expect(screen.getByText('bannerCalendar.poolDuration:')).toBeTruthy()
   })
 
   it('renders close button with accessible text', () => {
-    const { container } = render(<PoolInfoStrip />)
-    const bannerBtn = container.querySelector('button')
-    fireEvent.click(bannerBtn!)
-    const closeSpan = document.querySelector('span.sr-only')
-    expect(closeSpan).not.toBeNull()
-    expect(closeSpan?.textContent).toBe('common.close')
+    render(<PoolInfoStrip />)
+    const bannerButton = screen.getByRole('button', { name: /「临渊望北」特许寻访/ })
+    fireEvent.click(bannerButton)
+    expect(screen.getByRole('button', { name: 'common.close' })).toBeTruthy()
   })
 })

--- a/src/components/banner-calendar/pool-info-strip.tsx
+++ b/src/components/banner-calendar/pool-info-strip.tsx
@@ -9,13 +9,13 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
-  DialogDescription,
-  DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import { bannerEntries } from '@/data/banner'
 import type { BannerEntry } from '@/data/banner'
+
+const CARD_CLOSE_DURATION = 150 // ms — must match `duration-150` in animation classes
 
 export function PoolInfoStrip() {
   const t = useTranslations()
@@ -63,7 +63,7 @@ export function PoolInfoStrip() {
     closeTimerRef.current = setTimeout(() => {
       setCardState('closed')
       closeTimerRef.current = undefined
-    }, 150)
+    }, CARD_CLOSE_DURATION)
   }
 
   const formatDate = (iso: string) => {
@@ -142,11 +142,12 @@ export function PoolInfoStrip() {
       <Dialog open={!!selectedVisual} onOpenChange={(open) => {
         if (!open) { setSelectedVisual(null); setCardState('closed') }
       }}>
-        <DialogContent className="sm:max-w-4xl p-0 gap-0 overflow-hidden">
+        <DialogContent className="sm:max-w-4xl p-0 gap-0 overflow-hidden" showCloseButton={false}>
           <DialogClose className="absolute top-3 left-3 z-40 flex items-center justify-center size-8 rounded-full text-white/90 hover:text-white bg-black/30 hover:bg-black/50 transition-colors ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
             <X className="size-4" />
             <span className="sr-only">{t('common.close')}</span>
           </DialogClose>
+          <DialogTitle className="sr-only">{selectedVisual?.title ?? t('bannerCalendar.poolInfo')}</DialogTitle>
           {selectedVisual && (
             <div className="relative aspect-video w-full overflow-hidden rounded-[inherit]">
               {/* Banner image */}
@@ -181,6 +182,7 @@ export function PoolInfoStrip() {
                     type="button"
                     variant="ghost"
                     size="icon"
+                    aria-label={t('bannerCalendar.poolInfo')}
                     onClick={openCard}
                     className={cn(
                       'rounded-full text-white/90 hover:text-white',
@@ -217,16 +219,16 @@ export function PoolInfoStrip() {
                 >
                   {/* Header */}
                   <div className="px-4 pt-3 pb-1">
-                    <DialogHeader className="px-0 py-0">
-                      <DialogTitle className="text-sm font-semibold leading-tight">
+                    <div className="flex flex-col gap-2 px-0 py-0">
+                      <h3 className="text-sm font-semibold leading-tight">
                         {selectedVisual.title}
-                      </DialogTitle>
+                      </h3>
                       {selectedVisual.subtitle && (
-                        <DialogDescription className="text-xs text-muted-foreground mt-0.5">
+                        <p className="text-xs text-muted-foreground mt-0.5">
                           {selectedVisual.subtitle}
-                        </DialogDescription>
+                        </p>
                       )}
-                    </DialogHeader>
+                    </div>
                   </div>
 
                   {/* Body */}

--- a/src/components/banner-calendar/pool-info-strip.tsx
+++ b/src/components/banner-calendar/pool-info-strip.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useRef } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import Image from 'next/image'
 import { useTranslations, useLocale } from 'next-intl'
 import { Info, X } from 'lucide-react'
@@ -23,6 +23,15 @@ export function PoolInfoStrip() {
   const [selectedVisual, setSelectedVisual] = useState<BannerEntry | null>(null)
   const [cardState, setCardState] = useState<'closed' | 'open' | 'closing'>('closed')
   const closeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== undefined) {
+        clearTimeout(closeTimerRef.current)
+        closeTimerRef.current = undefined
+      }
+    }
+  }, [])
 
   // Sort by version descending
   const visuals = useMemo(() => {
@@ -168,18 +177,18 @@ export function PoolInfoStrip() {
               {/* Info button — only when card is closed */}
               {cardState === 'closed' && (
                 <div className="absolute top-3 right-3 z-20">
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="icon"
                     onClick={openCard}
                     className={cn(
-                      'flex items-center justify-center size-8 rounded-full',
-                      'text-white/90 hover:text-white',
-                      'bg-black/30 hover:bg-black/50',
-                      'transition-colors'
+                      'rounded-full text-white/90 hover:text-white',
+                      'bg-black/30 hover:bg-black/50'
                     )}
                   >
                     <Info className="size-4" />
-                  </button>
+                  </Button>
                 </div>
               )}
 
@@ -244,7 +253,7 @@ export function PoolInfoStrip() {
                           href={selectedVisual.officialUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className={buttonVariants({ variant: 'link', size: 'sm' }) + ' h-auto px-0 text-xs'}
+                          className={cn(buttonVariants({ variant: 'link', size: 'sm' }), 'h-auto px-0 text-xs')}
                         >
                           {t('bannerCalendar.viewDetails')}
                         </a>

--- a/src/components/banner-calendar/timeline-chart.tsx
+++ b/src/components/banner-calendar/timeline-chart.tsx
@@ -155,7 +155,7 @@ export function TimelineChart({ data, t }: TimelineChartProps) {
                   ch.statusBadge.type === 'rerunActive' && 'bg-emerald-500/20 text-emerald-400',
                   ch.statusBadge.type === 'upcoming' && 'bg-amber-500/20 text-amber-400',
                   ch.statusBadge.type === 'inPool' && 'bg-sky-500/20 text-sky-400',
-                  ch.statusBadge.type === 'notYetAppeared' && 'bg-violet-500/20 text-violet-400',
+                  ch.statusBadge.type === 'notYetAppeared' && 'bg-status-future/20 text-status-future',
                   ch.statusBadge.type === 'out' && 'bg-muted text-muted-foreground',
                   ch.statusBadge.type === 'standard' && 'bg-secondary text-secondary-foreground',
                 )}

--- a/src/data/banner.ts
+++ b/src/data/banner.ts
@@ -20,13 +20,13 @@ export interface BannerEntry {
 }
 
 // Future banners without visuals yet — schedule data only
-const PENDING_SCHEDULE: Record<string, { windows: BannerWindow[] }> = {
+const PENDING_SCHEDULE = {
   梨诺: {
     windows: [
-      { start: '2026-08-09T12:00:00+08:00', end: '2026-09-02T11:59:00+08:00', version: '1.4', period: 9, isRerun: false },
+      { start: '2026-08-09T12:00:00+08:00', end: '2026-09-02T11:59:00+08:00', version: '1.4', period: 10, isRerun: false },
     ],
   },
-}
+} as const satisfies Record<string, { windows: BannerWindow[] }>
 
 const STANDARD_CHARS = ['艾尔黛拉', '余烬', '黎风', '别礼', '骏卫'] as const
 export const standardCharacters: readonly string[] = STANDARD_CHARS


### PR DESCRIPTION
## Summary by Sourcery

引入统一的 banner 数据模块，并增强 banner 日历 UI 和状态处理。

新功能：
- 添加一个中心化的 banner 数据源，用于定义 banner 条目、推荐干员，并据此推导出卡池时间表和标准寻访干员列表。
- 使用新的 banner 条目数据结构展示卡池视觉信息，在卡池信息条对话框中提供内联的图片悬浮信息卡并改进交互体验。
- 在卡池时间轴中支持角色的“尚未实装”新状态，并为其提供专门的徽章文案和样式。

缺陷修复：
- 确保 banner 状态徽章能够正确区分那些从未出现过、但在未来已有卡池时间窗口的干员。

增强优化：
- 优化时间轴图表样式，尤其是复刻卡池条的表现，以便在视觉上更好地区分不同状态。
- 简化类型定义，移除旧的 `BannerVisual` 接口，改用新的 banner 条目模型，并更新相关导入以使用统一的 banner 数据模块。

测试：
- 为 banner 数据模块添加单元测试，用于验证时间表和标准寻访干员的导出结果。
- 为卡池信息条添加组件测试，用于验证其能根据 banner 条目渲染标题文本和卡池名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified banner data module and enhance the banner calendar UI and status handling.

New Features:
- Add a central banner data source that defines banner entries, featured operators, and derives the banner schedule and standard character list.
- Display banner pool visuals using the new banner entries data structure with an inline, image-overlay info card and improved interaction in the pool info strip dialog.
- Support a new "not yet appeared" status for characters in the banner timeline, including dedicated badge text and styling.

Bug Fixes:
- Ensure banner status badges correctly distinguish characters that have never appeared but have only future banner windows.

Enhancements:
- Refine timeline chart styling, especially for rerun banner bars, to better differentiate states visually.
- Simplify types by removing the old BannerVisual interface in favor of the new banner entry model and updating imports to use the unified banner data module.

Tests:
- Add unit tests for the banner data module to verify schedule and standard character exports.
- Add a component test for the pool info strip to verify it renders header text and banner titles from banner entries.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化横幅详情弹窗，支持信息卡片展开、关闭及动画过渡。
  * 增加关闭和信息按钮，并改善屏幕阅读器可访问性。
  * 横幅描述和官方链接的展示样式得到优化。

* **错误修复**
  * 修正待定日程中梨诺的活动周期。
  * 统一时间线中“尚未登场”状态的颜色样式。

* **测试**
  * 补充横幅信息条的交互、弹窗和无障碍行为测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->