### PR TITLE
Beta 1.4.11

### DIFF
--- a/scripts/SYNC_PIPELINE.md
+++ b/scripts/SYNC_PIPELINE.md
@@ -88,30 +88,25 @@ src/generated/i18n/
 
 ## 如何在前端使用
 
-### 1. Layout 自动合并
+### 1. 分层注入（Client vs Server）
 
-`src/app/[locale]/layout.tsx` 在服务端将游戏 i18n 合并到 `next-intl` 的 messages 中：
+同步产物仍是全量 generated JSON；**运行时不得把 wikiData 塞进根 layout 的 ClientProvider**（静态导出会把 messages 复制进每个页面 HTML）。
 
-```ts
-const messages = (await import(`../../messages/${locale}.json`)).default
-
-// 合并游戏内容翻译
-for (const category of ['weapons', 'equips', 'dungeons', 'stats', 'regions']) {
-  messages[category] = (await import(`../../generated/i18n/${category}/${locale}.json`)).default
-}
-```
-
-合并后，组件中可以直接使用 `t()` 访问：
+| API | 用途 | 是否含 wikiData |
+|-----|------|-----------------|
+| `loadClientMessages(locale)` | 根 layout `NextIntlClientProvider` | 否（UI + 规划器用短名表） |
+| `loadMessages(locale)` | `getRequestConfig` / 服务端 `getTranslations`（SSG） | 是 |
+| `@/lib/game-i18n-catalogs` | 客户端 wiki 长文案 / 实体名（共享 JS chunk） | wikiData 在此 |
 
 ```tsx
-// 武器名
-t('weapons.wpn_funnel_0017')   // → "雾中微光" (zh-CN) / "Flickers in the Mist" (en)
+// 规划器短名：仍走 next-intl（已在 ClientProvider）
+t('weapons.wpn_funnel_0017')
 
-// 地区名
-t('regions.fourthValley')      // → "四号谷地" / "Valley IV"
+// 地区名（namespace 为 region）
+t('region.fourthValley')
 
-// 淤积点名
-t('dungeons.hub')              // → "四号谷地·枢纽区" / "Valley IV·The Hub"
+// Wiki 长文案 / 技能描述：useWikiTranslations() 或 game-i18n-catalogs
+// 不要 useTranslations('wikiData')
 ```
 
 ### 2. 数据映射辅助

--- a/scripts/SYNC_PIPELINE.md
+++ b/scripts/SYNC_PIPELINE.md
@@ -96,7 +96,7 @@ src/generated/i18n/
 |-----|------|-----------------|
 | `loadClientMessages(locale)` | 根 layout `NextIntlClientProvider` | 否（UI + 规划器用短名表） |
 | `loadMessages(locale)` | `getRequestConfig` / 服务端 `getTranslations`（SSG） | 是 |
-| `@/lib/game-i18n-catalogs` | 客户端 wiki 长文案 / 实体名（共享 JS chunk） | wikiData 在此 |
+| `@/lib/game-i18n-catalogs` | 客户端 wiki 长文案 / 实体名（`import()` **按 locale 动态分包** + 缓存；layout 预加载当前语言） | wikiData 在此 |
 
 ```tsx
 // 规划器短名：仍走 next-intl（已在 ClientProvider）

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -26,6 +26,7 @@ import { VersionProvider } from '@/hooks/use-version'
 import { SiteUrlProvider } from '@/hooks/use-site-url'
 import { versionData } from '@/generated/version-data'
 import { DEFAULT_SITE_URL } from '@/lib/constants'
+import { GameI18nCatalogPreloader } from '@/components/shared/game-i18n-catalog-preloader'
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }))
@@ -70,6 +71,7 @@ export default async function LocaleLayout({
   return (
     <>
       <NextIntlClientProvider messages={messages} locale={locale}>
+      <GameI18nCatalogPreloader locale={locale} />
       <LocaleGuard />
       <DebugLabel />
       <SiteUrlProvider url={siteUrl}>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import { routing } from '@/i18n/routing'
-import { loadMessages } from '@/i18n/load-messages'
+import { loadClientMessages } from '@/i18n/load-messages'
 import type { WikiLocale } from '@/types/wiki'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
@@ -65,7 +65,7 @@ export default async function LocaleLayout({
   const siteUrl = DEFAULT_SITE_URL
   const t = await getTranslations({ locale })
 
-  const messages = loadMessages(locale as WikiLocale)
+  const messages = loadClientMessages(locale as WikiLocale)
 
   return (
     <>

--- a/src/components/panel-preview/equipment-suit-picker.test.tsx
+++ b/src/components/panel-preview/equipment-suit-picker.test.tsx
@@ -46,10 +46,27 @@ vi.mock('@/components/shared/planner-wiki-preview', () => ({
   PlannerWikiPreview: ({ rows }: { rows: Array<{ label: string }> }) => <div>{rows.map((row) => <span key={row.label}>{row.label}</span>)}</div>,
 }))
 
+vi.mock('@/hooks/use-mobile-long-press-tooltip', () => ({
+  useMobileLongPressTooltip: () => ({
+    open: true,
+    setOpen: vi.fn(),
+    triggerRef: { current: null },
+    longPressTriggered: { current: false },
+    handleOpenChange: vi.fn(),
+    handlePointerDown: vi.fn(),
+    handlePointerMove: vi.fn(),
+    handlePointerEnd: vi.fn(),
+    handleContextMenu: vi.fn(),
+    swallowLongPressClick: () => false,
+    isMobile: false,
+  }),
+}))
+
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   TooltipTrigger: ({ render: trigger }: { render: React.ReactNode }) => <>{trigger}</>,
   TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TOOLTIP_OPEN_DELAY_MS: 400,
 }))
 
 it('uses localized equipment stat labels in selection tooltips', () => {

--- a/src/components/panel-preview/equipment-suit-picker.tsx
+++ b/src/components/panel-preview/equipment-suit-picker.tsx
@@ -6,9 +6,9 @@ import { useLocale, useTranslations } from 'next-intl'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { RarityFrame } from '@/components/shared/rarity-frame'
+import { PlannerPreviewTooltip } from '@/components/shared/planner-preview-tooltip'
 import { PlannerWikiPreview } from '@/components/shared/planner-wiki-preview'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { RarityFrame } from '@/components/shared/rarity-frame'
 import { wikiEquipment } from '@/generated/data/wiki/equipment'
 import { wikiEquipmentPlannerPreviews } from '@/generated/data/wiki/planner-previews'
 import { useWikiTranslations } from '@/hooks/use-wiki-translations'
@@ -55,30 +55,74 @@ export function EquipmentSuitPicker({ partTypeId, selectedId, onSelect }: Equipm
       <div className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
         {groups.map((group) => {
           const open = expanded.has(group.key)
-          return <section key={group.key} className="overflow-hidden rounded-lg bg-card shadow-[var(--shadow-border)]">
-            <Button type="button" variant="ghost" className="min-h-11 w-full justify-start gap-2 px-3" aria-expanded={open} onClick={() => setExpanded((current) => {
-              const next = new Set(current)
-              if (next.has(group.key)) next.delete(group.key)
-              else next.add(group.key)
-              return next
-            })}>
-              <ChevronDown className={open ? 'transition-transform' : '-rotate-90 transition-transform'} />
-              <span className="min-w-0 flex-1 truncate text-left font-medium">{group.label}</span>
-              <Badge variant="secondary">{group.equipment.length}</Badge>
-            </Button>
-            {open && <div className="grid grid-cols-[repeat(auto-fill,minmax(7rem,1fr))] gap-2 p-3 pt-1">
-              {group.equipment.map((equipment) => {
-                const name = entityName(equipment)
-                const selected = equipment.id === selectedId
-                const preview = wikiEquipmentPlannerPreviews[equipment.id]
-                const previewLabels = preview?.stats[1] ?? preview?.stats[0]
-                const card = <Button type="button" variant="ghost" size="card" aria-pressed={selected} aria-label={name} className={cn('relative h-auto min-w-0 rounded-lg p-0 shadow-[var(--shadow-border)]', selected && cn('shadow-[0px_0px_0px_1px_#fbbf24,0_25px_50px_-12px_rgba(0,0,0,0.25)]', PLANNER_SELECTED_RING_CLASS))} onClick={() => onSelect(equipment)}>
-                  <RarityFrame imageSrc={`/images/equip/${equipment.imageId}.avif`} title={name} rarity={equipment.rarity} imageClassName="object-cover" className="w-full rounded-lg shadow-none" badges={selected ? <span className={cn('flex size-5 items-center justify-center rounded-full', PLANNER_SELECTED_BADGE_CLASS)}><Check className="size-3" /></span> : undefined} badgeClassName="left-auto right-1.5 top-1.5" />
-                </Button>
-                return preview ? <Tooltip key={equipment.id}><TooltipTrigger render={card} /><TooltipContent side="top" sideOffset={8} collisionPadding={16} className="max-h-[min(var(--available-height),calc(100svh-2rem))] max-w-[calc(100vw-2rem)] overflow-y-auto overscroll-contain bg-popover p-3 text-popover-foreground shadow-[var(--shadow-card)]"><PlannerWikiPreview title={name} rarity={equipment.rarity} compact levelOneLabel={previewLabels?.levelOneLabel} maxLevelLabel={previewLabels?.maxLevelLabel} rows={preview.stats.map((stat) => ({ label: equipmentStatLabel(stat.attributeId), levelOne: stat.levelOne, maxLevel: stat.maxLevel }))} wikiHref={`/${locale}/wiki/equipment/${equipment.id}`} /></TooltipContent></Tooltip> : card
-              })}
-            </div>}
-          </section>
+          return (
+            <section key={group.key} className="overflow-hidden rounded-lg bg-card shadow-[var(--shadow-border)]">
+              <Button
+                type="button"
+                variant="ghost"
+                className="min-h-11 w-full justify-start gap-2 px-3"
+                aria-expanded={open}
+                onClick={() => setExpanded((current) => {
+                  const next = new Set(current)
+                  if (next.has(group.key)) next.delete(group.key)
+                  else next.add(group.key)
+                  return next
+                })}
+              >
+                <ChevronDown className={open ? 'transition-transform' : '-rotate-90 transition-transform'} />
+                <span className="min-w-0 flex-1 truncate text-left font-medium">{group.label}</span>
+                <Badge variant="secondary">{group.equipment.length}</Badge>
+              </Button>
+              {open && (
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(7rem,1fr))] gap-2 p-3 pt-1">
+                  {group.equipment.map((equipment) => {
+                    const name = entityName(equipment)
+                    const selected = equipment.id === selectedId
+                    const preview = wikiEquipmentPlannerPreviews[equipment.id]
+                    const previewLabels = preview?.stats[1] ?? preview?.stats[0]
+                    const content = preview ? (
+                      <PlannerWikiPreview
+                        title={name}
+                        rarity={equipment.rarity}
+                        compact
+                        levelOneLabel={previewLabels?.levelOneLabel}
+                        maxLevelLabel={previewLabels?.maxLevelLabel}
+                        rows={preview.stats.map((stat) => ({
+                          label: equipmentStatLabel(stat.attributeId),
+                          levelOne: stat.levelOne,
+                          maxLevel: stat.maxLevel,
+                        }))}
+                        wikiHref={`/${locale}/wiki/equipment/${equipment.id}`}
+                      />
+                    ) : null
+                    return (
+                      <PlannerPreviewTooltip
+                        key={equipment.id}
+                        content={content}
+                        onClick={() => onSelect(equipment)}
+                        aria-label={name}
+                        aria-pressed={selected}
+                        className={cn(
+                          'relative h-auto min-w-0 rounded-lg p-0 shadow-[var(--shadow-border)]',
+                          selected && cn('shadow-[0px_0px_0px_1px_#fbbf24,0_25px_50px_-12px_rgba(0,0,0,0.25)]', PLANNER_SELECTED_RING_CLASS),
+                        )}
+                      >
+                        <RarityFrame
+                          imageSrc={`/images/equip/${equipment.imageId}.avif`}
+                          title={name}
+                          rarity={equipment.rarity}
+                          imageClassName="object-cover"
+                          className="w-full rounded-lg shadow-none"
+                          badges={selected ? <span className={cn('flex size-5 items-center justify-center rounded-full', PLANNER_SELECTED_BADGE_CLASS)}><Check className="size-3" /></span> : undefined}
+                          badgeClassName="left-auto right-1.5 top-1.5"
+                        />
+                      </PlannerPreviewTooltip>
+                    )
+                  })}
+                </div>
+              )}
+            </section>
+          )
         })}
       </div>
     </div>

--- a/src/components/shared/game-i18n-catalog-preloader.test.tsx
+++ b/src/components/shared/game-i18n-catalog-preloader.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { GameI18nCatalogPreloader } from './game-i18n-catalog-preloader'
+
+const loadGameI18nLocale = vi.fn((_locale: string) => Promise.resolve({} as never))
+
+vi.mock('@/lib/game-i18n-catalogs', () => ({
+  loadGameI18nLocale: (locale: string) => loadGameI18nLocale(locale),
+}))
+
+vi.mock('@/lib/wiki-locale', () => ({
+  asWikiLocale: (locale: string) =>
+    locale === 'en' || locale === 'ja' || locale === 'zh-CN' || locale === 'zh-TW' ? locale : 'zh-CN',
+}))
+
+afterEach(() => {
+  cleanup()
+  loadGameI18nLocale.mockClear()
+})
+
+it('loads normalized locale catalogs on mount', () => {
+  render(<GameI18nCatalogPreloader locale="en" />)
+  expect(loadGameI18nLocale).toHaveBeenCalledTimes(1)
+  expect(loadGameI18nLocale).toHaveBeenCalledWith('en')
+})
+
+it('reloads when locale changes and normalizes unknown locales', () => {
+  const { rerender } = render(<GameI18nCatalogPreloader locale="ja" />)
+  expect(loadGameI18nLocale).toHaveBeenLastCalledWith('ja')
+
+  rerender(<GameI18nCatalogPreloader locale="fr" />)
+  expect(loadGameI18nLocale).toHaveBeenLastCalledWith('zh-CN')
+  expect(loadGameI18nLocale).toHaveBeenCalledTimes(2)
+})

--- a/src/components/shared/game-i18n-catalog-preloader.tsx
+++ b/src/components/shared/game-i18n-catalog-preloader.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect } from 'react'
+import { loadGameI18nLocale } from '@/lib/game-i18n-catalogs'
+import { asWikiLocale } from '@/lib/wiki-locale'
+
+export interface GameI18nCatalogPreloaderProps {
+  locale: string
+}
+
+/**
+ * Kicks off per-locale catalog dynamic import as early as the locale layout mounts
+ * so wiki/planner hooks usually hit cache instead of flashing raw IDs.
+ */
+export function GameI18nCatalogPreloader({ locale }: GameI18nCatalogPreloaderProps) {
+  useEffect(() => {
+    void loadGameI18nLocale(asWikiLocale(locale))
+  }, [locale])
+
+  return null
+}
+
+export default GameI18nCatalogPreloader

--- a/src/components/shared/planner-preview-tooltip.test.tsx
+++ b/src/components/shared/planner-preview-tooltip.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { PlannerPreviewTooltip } from './planner-preview-tooltip'
+import { TOOLTIP_OPEN_DELAY_MS } from '@/components/ui/tooltip'
+
+vi.mock('@/hooks/use-mobile-long-press-tooltip', () => ({
+  useMobileLongPressTooltip: (enabled = true) => ({
+    open: false,
+    setOpen: vi.fn(),
+    triggerRef: { current: null },
+    longPressTriggered: { current: false },
+    handleOpenChange: vi.fn(),
+    handlePointerDown: vi.fn(),
+    handlePointerMove: vi.fn(),
+    handlePointerEnd: vi.fn(),
+    handleContextMenu: vi.fn(),
+    swallowLongPressClick: () => false,
+    isMobile: false,
+    enabled,
+  }),
+}))
+
+afterEach(cleanup)
+
+it('exports a 400ms open delay for the shared provider default', () => {
+  expect(TOOLTIP_OPEN_DELAY_MS).toBe(400)
+})
+
+it('invokes onClick for cards without preview content', () => {
+  const onClick = vi.fn()
+  render(
+    <PlannerPreviewTooltip content={null} onClick={onClick} aria-label="测试卡">
+      <span>卡面</span>
+    </PlannerPreviewTooltip>,
+  )
+  fireEvent.click(screen.getByRole('button', { name: '测试卡' }))
+  expect(onClick).toHaveBeenCalledTimes(1)
+})
+
+it('still renders an activatable card when preview content is present', () => {
+  const onClick = vi.fn()
+  render(
+    <PlannerPreviewTooltip content={<div>预览</div>} onClick={onClick} aria-label="有预览">
+      <span>卡面</span>
+    </PlannerPreviewTooltip>,
+  )
+  fireEvent.click(screen.getByRole('button', { name: '有预览' }))
+  expect(onClick).toHaveBeenCalledTimes(1)
+})

--- a/src/components/shared/planner-preview-tooltip.tsx
+++ b/src/components/shared/planner-preview-tooltip.tsx
@@ -15,8 +15,15 @@ export function plannerPreviewTooltipContentClassName(isMobile: boolean) {
 }
 
 export interface PlannerPreviewTooltipProps {
-  /** When false or content is empty, renders the card without tooltip chrome. */
+  /**
+   * Master switch. Tooltip chrome and scroll-lock subscription only activate when
+   * `enabled && content != null` (see `active` inside the component).
+   */
   enabled?: boolean
+  /**
+   * Preview body. When null/undefined/false, renders a plain card with no tooltip
+   * (and does not enable long-press / scroll-lock behavior).
+   */
   content?: ReactNode | null
   onClick: () => void
   className?: string
@@ -28,6 +35,9 @@ export interface PlannerPreviewTooltipProps {
 /**
  * Dense-grid entity card with desktop hover delay (via TooltipProvider)
  * and mobile long-press preview. Long-press release does not fire onClick.
+ *
+ * Activation = enabled (default true) AND content present. That flag is passed to
+ * useMobileLongPressTooltip so inactive cards skip long-press and scroll-close wiring.
  */
 export function PlannerPreviewTooltip({
   enabled = true,

--- a/src/components/shared/planner-preview-tooltip.tsx
+++ b/src/components/shared/planner-preview-tooltip.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useMobileLongPressTooltip } from '@/hooks/use-mobile-long-press-tooltip'
+import { cn } from '@/lib/utils'
+
+/** Shared surface styles for dense planner / picker preview tooltips. */
+export function plannerPreviewTooltipContentClassName(isMobile: boolean) {
+  return cn(
+    'max-h-[min(var(--available-height),calc(100svh-2rem))] max-w-[calc(100vw-2rem)] overflow-y-auto overscroll-contain bg-popover p-3 text-popover-foreground shadow-[var(--shadow-card)]',
+    isMobile && 'data-closed:animate-none',
+  )
+}
+
+export interface PlannerPreviewTooltipProps {
+  /** When false or content is empty, renders the card without tooltip chrome. */
+  enabled?: boolean
+  content?: ReactNode | null
+  onClick: () => void
+  className?: string
+  'aria-label'?: string
+  'aria-pressed'?: boolean
+  children: ReactNode
+}
+
+/**
+ * Dense-grid entity card with desktop hover delay (via TooltipProvider)
+ * and mobile long-press preview. Long-press release does not fire onClick.
+ */
+export function PlannerPreviewTooltip({
+  enabled = true,
+  content,
+  onClick,
+  className,
+  'aria-label': ariaLabel,
+  'aria-pressed': ariaPressed,
+  children,
+}: PlannerPreviewTooltipProps) {
+  const active = Boolean(enabled && content != null && content !== false)
+  const {
+    open,
+    triggerRef,
+    handleOpenChange,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerEnd,
+    handleContextMenu,
+    swallowLongPressClick,
+    isMobile,
+  } = useMobileLongPressTooltip(active)
+
+  const handleClick = () => {
+    if (swallowLongPressClick()) return
+    onClick()
+  }
+
+  const trigger = (
+    <Button
+      ref={triggerRef}
+      type="button"
+      variant="ghost"
+      size="card"
+      aria-label={ariaLabel}
+      aria-pressed={ariaPressed}
+      onClick={handleClick}
+      onPointerDown={isMobile && active ? handlePointerDown : undefined}
+      onPointerMove={isMobile && active ? handlePointerMove : undefined}
+      onPointerUp={isMobile && active ? handlePointerEnd : undefined}
+      onPointerCancel={isMobile && active ? handlePointerEnd : undefined}
+      onContextMenu={isMobile && active ? handleContextMenu : undefined}
+      className={cn(
+        active && isMobile && 'touch-manipulation select-none [-webkit-touch-callout:none] [-webkit-user-select:none] [&_img]:pointer-events-none [&_img]:select-none',
+        className,
+      )}
+    >
+      {children}
+    </Button>
+  )
+
+  if (!active) return trigger
+
+  return (
+    <Tooltip open={open} onOpenChange={handleOpenChange}>
+      <TooltipTrigger render={trigger} />
+      <TooltipContent
+        side={isMobile ? 'bottom' : 'top'}
+        sideOffset={8}
+        collisionPadding={16}
+        className={plannerPreviewTooltipContentClassName(isMobile)}
+      >
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export default PlannerPreviewTooltip

--- a/src/components/shared/wiki-entity-picker.test.tsx
+++ b/src/components/shared/wiki-entity-picker.test.tsx
@@ -17,31 +17,23 @@ vi.mock('next-intl', () => ({
   },
 }))
 
-vi.mock('@/lib/game-i18n-catalogs', () => {
-  const characters: Record<string, string> = {
-    high: '高星',
-    low: '低星',
-    one: '佩丽卡',
-    two: '陈千语',
-  }
-  const wikiData: Record<string, string> = {
-    'enum|elements|Physical': '物理',
-    'enum|elements|Natural': '自然',
-  }
-
-  return {
-    hasGameI18n: (_locale: string, namespace: string, key: string) => {
-      if (namespace === 'characters') return key in characters
-      if (namespace === 'wikiData') return key in wikiData
-      return false
+vi.mock('@/hooks/use-game-i18n-catalogs', () => ({
+  useGameI18nLocale: () => ({
+    characters: {
+      high: '高星',
+      low: '低星',
+      one: '佩丽卡',
+      two: '陈千语',
     },
-    lookupGameI18n: (_locale: string, namespace: string, key: string) => {
-      if (namespace === 'characters') return characters[key]
-      if (namespace === 'wikiData') return wikiData[key]
-      return undefined
+    weapons: {},
+    equips: {},
+    equipStats: {},
+    wikiData: {
+      'enum|elements|Physical': '物理',
+      'enum|elements|Natural': '自然',
     },
-  }
-})
+  }),
+}))
 
 vi.mock('@/hooks/use-mobile-long-press-tooltip', () => ({
   useMobileLongPressTooltip: () => ({

--- a/src/components/shared/wiki-entity-picker.test.tsx
+++ b/src/components/shared/wiki-entity-picker.test.tsx
@@ -7,19 +7,40 @@ import type { WikiCharacterSummary } from '@/types/wiki'
 
 vi.mock('next-intl', () => ({
   useLocale: () => 'zh-CN',
-  useTranslations: (namespace?: string) => {
-    const values = namespace === 'characters'
-      ? { high: '高星', low: '低星', one: '佩丽卡', two: '陈千语' }
-      : namespace === 'wikiData'
-        ? { 'enum|elements|Physical': '物理', 'enum|elements|Natural': '自然' }
-        : {}
-    const translate = Object.assign((key: string) => values[key as keyof typeof values] ?? key, {
-      has: (key: string) => key in values,
-      raw: (key: string) => values[key as keyof typeof values] ?? key,
+  useTranslations: () => {
+    const translate = Object.assign((key: string) => key, {
+      has: () => false,
+      raw: (key: string) => key,
     })
     return translate
   },
 }))
+
+vi.mock('@/lib/game-i18n-catalogs', () => {
+  const characters: Record<string, string> = {
+    high: '高星',
+    low: '低星',
+    one: '佩丽卡',
+    two: '陈千语',
+  }
+  const wikiData: Record<string, string> = {
+    'enum|elements|Physical': '物理',
+    'enum|elements|Natural': '自然',
+  }
+
+  return {
+    hasGameI18n: (_locale: string, namespace: string, key: string) => {
+      if (namespace === 'characters') return key in characters
+      if (namespace === 'wikiData') return key in wikiData
+      return false
+    },
+    lookupGameI18n: (_locale: string, namespace: string, key: string) => {
+      if (namespace === 'characters') return characters[key]
+      if (namespace === 'wikiData') return wikiData[key]
+      return undefined
+    },
+  }
+})
 
 afterEach(cleanup)
 

--- a/src/components/shared/wiki-entity-picker.test.tsx
+++ b/src/components/shared/wiki-entity-picker.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { cloneElement, isValidElement, type ReactElement, type ReactNode } from 'react'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { WikiEntityPicker } from './wiki-entity-picker'
@@ -41,6 +42,41 @@ vi.mock('@/lib/game-i18n-catalogs', () => {
     },
   }
 })
+
+vi.mock('@/hooks/use-mobile-long-press-tooltip', () => ({
+  useMobileLongPressTooltip: () => ({
+    open: false,
+    setOpen: vi.fn(),
+    triggerRef: { current: null },
+    longPressTriggered: { current: false },
+    handleOpenChange: vi.fn(),
+    handlePointerDown: vi.fn(),
+    handlePointerMove: vi.fn(),
+    handlePointerEnd: vi.fn(),
+    handleContextMenu: vi.fn(),
+    swallowLongPressClick: () => false,
+    isMobile: false,
+  }),
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({
+    render: trigger,
+    children,
+  }: {
+    render: ReactElement
+    children?: ReactNode
+  }) => {
+    if (!isValidElement(trigger)) return null
+    return cloneElement(trigger, {
+      'data-slot': 'tooltip-trigger',
+      children: children ?? (trigger.props as { children?: ReactNode }).children,
+    } as never)
+  },
+  TooltipContent: ({ children }: { children: ReactNode }) => <div data-testid="tooltip-content">{children}</div>,
+  TOOLTIP_OPEN_DELAY_MS: 400,
+}))
 
 afterEach(cleanup)
 

--- a/src/components/shared/wiki-entity-picker.tsx
+++ b/src/components/shared/wiki-entity-picker.tsx
@@ -7,8 +7,8 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { FilterChip } from '@/components/shared/filter-chip'
+import { PlannerPreviewTooltip } from '@/components/shared/planner-preview-tooltip'
 import { RarityFrame } from '@/components/shared/rarity-frame'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { sortWikiEntities } from '@/components/wiki/wiki-entity-grid'
 import { useWikiTranslations } from '@/hooks/use-wiki-translations'
 import { PLANNER_SELECTED_BADGE_CLASS, PLANNER_SELECTED_RING_CLASS } from '@/lib/planner-selection-styles'
@@ -118,11 +118,28 @@ export function WikiEntityPicker({ title, entities, imageBasePath, selectedIds, 
         {filtered.map((entity) => {
           const name = entityName(entity)
           const isSelected = selected.has(entity.id)
-          const card = <Button key={entity.id} type="button" variant="ghost" size="card" aria-pressed={isSelected} aria-label={name} onClick={() => onSelect(entity)} className={cn('relative h-auto min-w-0 self-start rounded-lg p-0 shadow-[var(--shadow-border)]', isSelected && selectedRingClass)}>
-            <RarityFrame imageSrc={`${imageBasePath}/${entity.imageId}.avif`} backgroundSrc={entity.category === 'characters' ? '/images/character-frame-bg.png' : undefined} title={name} rarity={entity.rarity} imageClassName={entity.category === 'weapons' ? 'object-contain p-3' : 'object-cover'} className={cn('w-full rounded-lg shadow-none', entity.category === 'characters' && 'aspect-[38/47]')} badges={isSelected ? <span className={cn('flex size-5 items-center justify-center rounded-full', selectedBadgeClass)}><Check className="size-3" /></span> : undefined} badgeClassName="left-auto right-1.5 top-1.5" />
-          </Button>
           const tooltip = renderTooltip?.(entity)
-          return tooltip ? <Tooltip key={entity.id}><TooltipTrigger render={card} /><TooltipContent side="top" sideOffset={8} collisionPadding={16} className="max-h-[min(var(--available-height),calc(100svh-2rem))] max-w-[calc(100vw-2rem)] overflow-y-auto overscroll-contain bg-popover p-3 text-popover-foreground shadow-[var(--shadow-card)]">{tooltip}</TooltipContent></Tooltip> : card
+          return (
+            <PlannerPreviewTooltip
+              key={entity.id}
+              content={tooltip}
+              onClick={() => onSelect(entity)}
+              aria-label={name}
+              aria-pressed={isSelected}
+              className={cn('relative h-auto min-w-0 self-start rounded-lg p-0 shadow-[var(--shadow-border)]', isSelected && selectedRingClass)}
+            >
+              <RarityFrame
+                imageSrc={`${imageBasePath}/${entity.imageId}.avif`}
+                backgroundSrc={entity.category === 'characters' ? '/images/character-frame-bg.png' : undefined}
+                title={name}
+                rarity={entity.rarity}
+                imageClassName={entity.category === 'weapons' ? 'object-contain p-3' : 'object-cover'}
+                className={cn('w-full rounded-lg shadow-none', entity.category === 'characters' && 'aspect-[38/47]')}
+                badges={isSelected ? <span className={cn('flex size-5 items-center justify-center rounded-full', selectedBadgeClass)}><Check className="size-3" /></span> : undefined}
+                badgeClassName="left-auto right-1.5 top-1.5"
+              />
+            </PlannerPreviewTooltip>
+          )
         })}
       </div>
       {filtered.length === 0 && <p className="py-8 text-center text-sm text-muted-foreground">{t('wiki.noMatch')}</p>}

--- a/src/components/shared/wiki-material-list.test.tsx
+++ b/src/components/shared/wiki-material-list.test.tsx
@@ -5,11 +5,14 @@ import { NextIntlClientProvider } from 'next-intl'
 import { afterEach, expect, it, vi } from 'vitest'
 import { formatMaterialCount, WikiMaterialList } from './wiki-material-list'
 
-vi.mock('@/lib/game-i18n-catalogs', () => ({
-  hasGameI18n: (_locale: string, namespace: string, key: string) =>
-    namespace === 'wikiData' && key === 'item|material-a',
-  lookupGameI18n: (_locale: string, namespace: string, key: string) =>
-    namespace === 'wikiData' && key === 'item|material-a' ? '测试材料' : undefined,
+vi.mock('@/hooks/use-game-i18n-catalogs', () => ({
+  useGameI18nLocale: () => ({
+    characters: {},
+    weapons: {},
+    equips: {},
+    equipStats: {},
+    wikiData: { 'item|material-a': '测试材料' },
+  }),
 }))
 
 const localized = (value: string) => ({ 'zh-CN': value, en: value, ja: value, 'zh-TW': value })

--- a/src/components/shared/wiki-material-list.test.tsx
+++ b/src/components/shared/wiki-material-list.test.tsx
@@ -2,12 +2,20 @@
 
 import { cleanup, render, screen } from '@testing-library/react'
 import { NextIntlClientProvider } from 'next-intl'
-import { afterEach, expect, it } from 'vitest'
+import { afterEach, expect, it, vi } from 'vitest'
 import { formatMaterialCount, WikiMaterialList } from './wiki-material-list'
+
+vi.mock('@/lib/game-i18n-catalogs', () => ({
+  hasGameI18n: (_locale: string, namespace: string, key: string) =>
+    namespace === 'wikiData' && key === 'item|material-a',
+  lookupGameI18n: (_locale: string, namespace: string, key: string) =>
+    namespace === 'wikiData' && key === 'item|material-a' ? '测试材料' : undefined,
+}))
 
 const localized = (value: string) => ({ 'zh-CN': value, en: value, ja: value, 'zh-TW': value })
 
 afterEach(cleanup)
+
 it('formats material counts in thousands without changing smaller values', () => {
   expect(formatMaterialCount(999)).toBe('999')
   expect(formatMaterialCount(1000)).toBe('1k')
@@ -17,11 +25,11 @@ it('formats material counts in thousands without changing smaller values', () =>
 
 it('keeps material text outside rarity-framed icons', () => {
   render(
-    <NextIntlClientProvider locale="zh-CN" messages={{ wikiData: { 'item|material-a': '测试材料' }, characters: {}, weapons: {}, equips: {} }}>
+    <NextIntlClientProvider locale="zh-CN" messages={{}} timeZone="UTC">
       <WikiMaterialList materials={[
         { itemId: 'material-a', name: localized('测试材料'), iconId: 'material-a', rarity: 4, count: 12 },
       ]} />
-    </NextIntlClientProvider>
+    </NextIntlClientProvider>,
   )
 
   expect(screen.getByText('测试材料')).toBeTruthy()
@@ -32,11 +40,11 @@ it('keeps material text outside rarity-framed icons', () => {
 
 it('supports compact icon and count only rendering', () => {
   render(
-    <NextIntlClientProvider locale="zh-CN" messages={{ wikiData: { 'item|material-a': '测试材料' }, characters: {}, weapons: {}, equips: {} }}>
+    <NextIntlClientProvider locale="zh-CN" messages={{}} timeZone="UTC">
       <WikiMaterialList iconOnly compact materials={[
         { itemId: 'material-a', name: localized('测试材料'), iconId: 'material-a', rarity: 4, count: 12 },
       ]} />
-    </NextIntlClientProvider>
+    </NextIntlClientProvider>,
   )
 
   expect(screen.queryByText('测试材料')).toBeNull()

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -4,8 +4,11 @@ import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
 
 import { cn } from "@/lib/utils"
 
+/** Default open delay (ms). Filters accidental flyovers on dense grids. */
+export const TOOLTIP_OPEN_DELAY_MS = 400
+
 function TooltipProvider({
-  delay = 0,
+  delay = TOOLTIP_OPEN_DELAY_MS,
   ...props
 }: TooltipPrimitive.Provider.Props) {
   return (

--- a/src/components/wiki/wiki-rich-text.test.tsx
+++ b/src/components/wiki/wiki-rich-text.test.tsx
@@ -8,13 +8,17 @@ vi.mock('next-intl', () => ({
   useLocale: () => 'en',
 }))
 
-vi.mock('@/lib/game-i18n-catalogs', () => ({
-  hasGameI18n: (_locale: string, namespace: string, key: string) =>
-    namespace === 'wikiData' && key.includes('ba%2Econsume'),
-  lookupGameI18n: (_locale: string, namespace: string, key: string) => {
-    if (namespace !== 'wikiData' || !key.includes('ba%2Econsume')) return undefined
-    return key.endsWith('|name') ? 'Consume' : 'Consume description'
-  },
+vi.mock('@/hooks/use-game-i18n-catalogs', () => ({
+  useGameI18nLocale: () => ({
+    characters: {},
+    weapons: {},
+    equips: {},
+    equipStats: {},
+    wikiData: {
+      'glossary|ba%2Econsume|name': 'Consume',
+      'glossary|ba%2Econsume|description': 'Consume description',
+    },
+  }),
 }))
 
 describe('WikiRichText', () => {

--- a/src/components/wiki/wiki-rich-text.test.tsx
+++ b/src/components/wiki/wiki-rich-text.test.tsx
@@ -5,10 +5,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { WikiRichText } from './wiki-rich-text'
 
 vi.mock('next-intl', () => ({
-  useTranslations: () => Object.assign((key: string) => key, {
-    has: (key: string) => key.includes('ba%2Econsume'),
-    raw: (key: string) => key.endsWith('|name') ? 'Consume' : 'Consume description',
-  }),
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/lib/game-i18n-catalogs', () => ({
+  hasGameI18n: (_locale: string, namespace: string, key: string) =>
+    namespace === 'wikiData' && key.includes('ba%2Econsume'),
+  lookupGameI18n: (_locale: string, namespace: string, key: string) => {
+    if (namespace !== 'wikiData' || !key.includes('ba%2Econsume')) return undefined
+    return key.endsWith('|name') ? 'Consume' : 'Consume description'
+  },
 }))
 
 describe('WikiRichText', () => {

--- a/src/components/wiki/wiki-rich-text.tsx
+++ b/src/components/wiki/wiki-rich-text.tsx
@@ -1,16 +1,24 @@
 'use client'
 
 import { Fragment, type ReactNode } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import glossaryData from '@/generated/data/wiki/rich-text.json'
+import { hasGameI18n, lookupGameI18n } from '@/lib/game-i18n-catalogs'
 import { parseWikiRichText, type WikiRichTextNode } from '@/lib/wiki-rich-text'
 import { cn } from '@/lib/utils'
 import { wikiTextKey } from '@/lib/wiki-i18n'
-import type { WikiRichTextTerm } from '@/types/wiki'
+import type { WikiLocale, WikiRichTextTerm } from '@/types/wiki'
 
 const glossary = glossaryData as Record<string, WikiRichTextTerm>
+
+function asWikiLocale(locale: string): WikiLocale {
+  if (locale === 'en' || locale === 'ja' || locale === 'zh-CN' || locale === 'zh-TW') {
+    return locale
+  }
+  return 'zh-CN'
+}
 
 function styleClass(styleId: string) {
   if (/fire|burn/i.test(styleId)) return 'text-ship-red'
@@ -73,11 +81,10 @@ export interface WikiRichTextProps {
   className?: string
 }
 export function WikiRichText({ value, className }: WikiRichTextProps) {
-  const t = useTranslations('wikiData')
+  const locale = asWikiLocale(useLocale())
   const translate = (key: string) => {
-    if (!t.has(key)) return key
-    const message = t.raw(key)
-    return typeof message === 'string' ? message : key
+    if (!hasGameI18n(locale, 'wikiData', key)) return key
+    return lookupGameI18n(locale, 'wikiData', key) ?? key
   }
   return <span className={cn('whitespace-pre-line', className)}>{renderNodes(parseWikiRichText(value), translate)}</span>
 }

--- a/src/components/wiki/wiki-rich-text.tsx
+++ b/src/components/wiki/wiki-rich-text.tsx
@@ -5,20 +5,14 @@ import { useLocale } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import glossaryData from '@/generated/data/wiki/rich-text.json'
-import { hasGameI18n, lookupGameI18n } from '@/lib/game-i18n-catalogs'
+import { useGameI18nLocale } from '@/hooks/use-game-i18n-catalogs'
 import { parseWikiRichText, type WikiRichTextNode } from '@/lib/wiki-rich-text'
 import { cn } from '@/lib/utils'
+import { asWikiLocale } from '@/lib/wiki-locale'
 import { wikiTextKey } from '@/lib/wiki-i18n'
-import type { WikiLocale, WikiRichTextTerm } from '@/types/wiki'
+import type { WikiRichTextTerm } from '@/types/wiki'
 
 const glossary = glossaryData as Record<string, WikiRichTextTerm>
-
-function asWikiLocale(locale: string): WikiLocale {
-  if (locale === 'en' || locale === 'ja' || locale === 'zh-CN' || locale === 'zh-TW') {
-    return locale
-  }
-  return 'zh-CN'
-}
 
 function styleClass(styleId: string) {
   if (/fire|burn/i.test(styleId)) return 'text-ship-red'
@@ -82,9 +76,10 @@ export interface WikiRichTextProps {
 }
 export function WikiRichText({ value, className }: WikiRichTextProps) {
   const locale = asWikiLocale(useLocale())
+  const catalogs = useGameI18nLocale(locale)
   const translate = (key: string) => {
-    if (!hasGameI18n(locale, 'wikiData', key)) return key
-    return lookupGameI18n(locale, 'wikiData', key) ?? key
+    const message = catalogs?.wikiData[key]
+    return typeof message === 'string' ? message : key
   }
   return <span className={cn('whitespace-pre-line', className)}>{renderNodes(parseWikiRichText(value), translate)}</span>
 }

--- a/src/hooks/use-close-on-scroll.test.tsx
+++ b/src/hooks/use-close-on-scroll.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { useState } from 'react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { useCloseOnScroll } from './use-close-on-scroll'
+
+function Harness() {
+  const [open, setOpen] = useState(true)
+  const ref = useCloseOnScroll(open, () => setOpen(false))
+  return (
+    <div>
+      <button ref={ref} type="button">{open ? 'open' : 'closed'}</button>
+      <div data-slot="tooltip-content">inside tip</div>
+    </div>
+  )
+}
+
+afterEach(cleanup)
+
+it('closes on window wheel outside the tooltip content', () => {
+  render(<Harness />)
+  expect(screen.getByRole('button').textContent).toBe('open')
+  act(() => {
+    fireEvent.wheel(window)
+  })
+  expect(screen.getByRole('button').textContent).toBe('closed')
+})
+
+it('does not close when wheel happens inside tooltip content', () => {
+  render(<Harness />)
+  act(() => {
+    fireEvent.wheel(screen.getByText('inside tip'))
+  })
+  expect(screen.getByRole('button').textContent).toBe('open')
+})

--- a/src/hooks/use-close-on-scroll.ts
+++ b/src/hooks/use-close-on-scroll.ts
@@ -6,12 +6,17 @@ import { useEffect, useRef } from 'react'
  * the container without moving the mouse — which would otherwise cause
  * the portal-rendered popup to drift outside the viewport and trigger
  * unwanted horizontal scrollbars.
+ *
+ * Callers should treat scroll-close as "suppress reopen until pointer leaves"
+ * so Base UI hover does not instantly flash the tooltip back open.
  */
 export function useCloseOnScroll(
   open: boolean,
-  setOpen: (open: boolean) => void,
+  onScrollClose: () => void,
 ) {
   const ref = useRef<HTMLButtonElement>(null)
+  const onScrollCloseRef = useRef(onScrollClose)
+  onScrollCloseRef.current = onScrollClose
 
   useEffect(() => {
     if (!open || !ref.current) return
@@ -28,28 +33,29 @@ export function useCloseOnScroll(
 
     const handler = (event: Event) => {
       const target = event.target
+      // Allow scrolling inside the tooltip popup itself (long previews).
       if (target instanceof Element && target.closest('[data-slot="tooltip-content"]')) return
-      setOpen(false)
+      onScrollCloseRef.current()
     }
-    scrollables.forEach((el) => {
-      el.addEventListener('scroll', handler, { passive: true })
-      el.addEventListener('wheel', handler, { passive: true })
+    scrollables.forEach((node) => {
+      node.addEventListener('scroll', handler, { passive: true })
+      node.addEventListener('wheel', handler, { passive: true })
     })
     window.addEventListener('scroll', handler, { passive: true })
     window.addEventListener('wheel', handler, { passive: true })
     document.scrollingElement?.addEventListener('scroll', handler, { passive: true })
     document.scrollingElement?.addEventListener('wheel', handler, { passive: true })
     return () => {
-      scrollables.forEach((el) => {
-        el.removeEventListener('scroll', handler)
-        el.removeEventListener('wheel', handler)
+      scrollables.forEach((node) => {
+        node.removeEventListener('scroll', handler)
+        node.removeEventListener('wheel', handler)
       })
       window.removeEventListener('scroll', handler)
       window.removeEventListener('wheel', handler)
       document.scrollingElement?.removeEventListener('scroll', handler)
       document.scrollingElement?.removeEventListener('wheel', handler)
     }
-  }, [open, setOpen])
+  }, [open])
 
   return ref
 }

--- a/src/hooks/use-close-on-scroll.ts
+++ b/src/hooks/use-close-on-scroll.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useEffectEvent, useRef } from 'react'
 
 /**
  * Dismiss a controlled tooltip when any scrollable ancestor scrolls.
@@ -15,8 +15,7 @@ export function useCloseOnScroll(
   onScrollClose: () => void,
 ) {
   const ref = useRef<HTMLButtonElement>(null)
-  const onScrollCloseRef = useRef(onScrollClose)
-  onScrollCloseRef.current = onScrollClose
+  const onScrollCloseEvent = useEffectEvent(onScrollClose)
 
   useEffect(() => {
     if (!open || !ref.current) return
@@ -35,7 +34,7 @@ export function useCloseOnScroll(
       const target = event.target
       // Allow scrolling inside the tooltip popup itself (long previews).
       if (target instanceof Element && target.closest('[data-slot="tooltip-content"]')) return
-      onScrollCloseRef.current()
+      onScrollCloseEvent()
     }
     scrollables.forEach((node) => {
       node.addEventListener('scroll', handler, { passive: true })

--- a/src/hooks/use-game-i18n-catalogs.test.tsx
+++ b/src/hooks/use-game-i18n-catalogs.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { useGameI18nLocale } from './use-game-i18n-catalogs'
+import type { GameI18nLocaleBundle } from '@/lib/game-i18n-catalogs'
+import type { WikiLocale } from '@/types/wiki'
+
+const enBundle = {
+  characters: { a: 'A' },
+  weapons: {},
+  equips: {},
+  equipStats: {},
+  wikiData: { k: 'en' },
+} as unknown as GameI18nLocaleBundle
+
+const jaBundle = {
+  characters: { a: 'ア' },
+  weapons: {},
+  equips: {},
+  equipStats: {},
+  wikiData: { k: 'ja' },
+} as unknown as GameI18nLocaleBundle
+
+const cache = new Map<string, GameI18nLocaleBundle>()
+const loadGameI18nLocale = vi.fn(async (locale: string) => {
+  const bundle = locale === 'ja' ? jaBundle : enBundle
+  cache.set(locale, bundle)
+  return bundle
+})
+
+vi.mock('@/lib/game-i18n-catalogs', () => ({
+  getCachedGameI18nLocale: (locale: string) => cache.get(locale),
+  loadGameI18nLocale: (locale: string) => loadGameI18nLocale(locale),
+}))
+
+afterEach(() => {
+  cleanup()
+  cache.clear()
+  loadGameI18nLocale.mockClear()
+})
+
+it('returns null until load resolves, then the locale bundle', async () => {
+  const { result } = renderHook(() => useGameI18nLocale('en'))
+  expect(result.current).toBeNull()
+
+  await waitFor(() => {
+    expect(result.current?.wikiData.k).toBe('en')
+  })
+  expect(loadGameI18nLocale).toHaveBeenCalledWith('en')
+})
+
+it('does not surface a stale locale bundle after locale changes', async () => {
+  let resolveEn!: (value: GameI18nLocaleBundle) => void
+  loadGameI18nLocale.mockImplementationOnce(
+    () =>
+      new Promise<GameI18nLocaleBundle>((resolve) => {
+        resolveEn = resolve
+      }),
+  )
+  loadGameI18nLocale.mockImplementationOnce(async (locale: string) => {
+    cache.set(locale, jaBundle)
+    return jaBundle
+  })
+
+  const { result, rerender } = renderHook(
+    ({ locale }: { locale: WikiLocale }) => useGameI18nLocale(locale),
+    { initialProps: { locale: 'en' as WikiLocale } },
+  )
+
+  rerender({ locale: 'ja' })
+  await waitFor(() => {
+    expect(result.current?.wikiData.k).toBe('ja')
+  })
+
+  await act(async () => {
+    resolveEn(enBundle)
+    cache.set('en', enBundle)
+  })
+
+  // Still on ja — late en resolve must not replace the returned catalog.
+  expect(result.current?.wikiData.k).toBe('ja')
+})

--- a/src/hooks/use-game-i18n-catalogs.ts
+++ b/src/hooks/use-game-i18n-catalogs.ts
@@ -8,32 +8,37 @@ import {
 } from '@/lib/game-i18n-catalogs'
 import type { WikiLocale } from '@/types/wiki'
 
+type LoadedEntry = {
+  locale: WikiLocale
+  bundle: GameI18nLocaleBundle
+}
+
 /**
  * Subscribe to per-locale game i18n catalogs (dynamic import + cache).
- * Returns null until the locale bundle has loaded (or cache hit on first paint).
+ *
+ * Return value is derived on render from:
+ * 1) shared cache for the current locale, or
+ * 2) state only when it matches the current locale (ignores stale loads).
+ *
+ * The effect never writes sync setState for cache hits / resets — it only
+ * updates after loadGameI18nLocale resolves (with cancellation).
  */
 export function useGameI18nLocale(locale: WikiLocale): GameI18nLocaleBundle | null {
-  const [bundle, setBundle] = useState<GameI18nLocaleBundle | null>(
-    () => getCachedGameI18nLocale(locale) ?? null,
-  )
+  const [entry, setEntry] = useState<LoadedEntry | null>(null)
 
   useEffect(() => {
     let cancelled = false
-    const cached = getCachedGameI18nLocale(locale)
-    if (cached) {
-      setBundle(cached)
-      return
-    }
-
-    setBundle(null)
-    void loadGameI18nLocale(locale).then((next) => {
-      if (!cancelled) setBundle(next)
+    void loadGameI18nLocale(locale).then((bundle) => {
+      if (cancelled) return
+      setEntry({ locale, bundle })
     })
-
     return () => {
       cancelled = true
     }
   }, [locale])
 
-  return bundle
+  const cached = getCachedGameI18nLocale(locale)
+  if (cached) return cached
+  if (entry?.locale === locale) return entry.bundle
+  return null
 }

--- a/src/hooks/use-game-i18n-catalogs.ts
+++ b/src/hooks/use-game-i18n-catalogs.ts
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import {
+  getCachedGameI18nLocale,
+  loadGameI18nLocale,
+  type GameI18nLocaleBundle,
+} from '@/lib/game-i18n-catalogs'
+import type { WikiLocale } from '@/types/wiki'
+
+/**
+ * Subscribe to per-locale game i18n catalogs (dynamic import + cache).
+ * Returns null until the locale bundle has loaded (or cache hit on first paint).
+ */
+export function useGameI18nLocale(locale: WikiLocale): GameI18nLocaleBundle | null {
+  const [bundle, setBundle] = useState<GameI18nLocaleBundle | null>(
+    () => getCachedGameI18nLocale(locale) ?? null,
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    const cached = getCachedGameI18nLocale(locale)
+    if (cached) {
+      setBundle(cached)
+      return
+    }
+
+    setBundle(null)
+    void loadGameI18nLocale(locale).then((next) => {
+      if (!cancelled) setBundle(next)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [locale])
+
+  return bundle
+}

--- a/src/hooks/use-mobile-long-press-tooltip.desktop.test.tsx
+++ b/src/hooks/use-mobile-long-press-tooltip.desktop.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { useMobileLongPressTooltip } from './use-mobile-long-press-tooltip'
+import {
+  ensureTooltipScrollLockInstalled,
+  lockTooltipsForScroll,
+  resetTooltipScrollLockForTests,
+} from '@/lib/tooltip-scroll-lock'
+
+vi.mock('./use-mobile', () => ({
+  useIsMobile: () => false,
+}))
+
+function DesktopCard({ id }: { id: string }) {
+  const { open, handleOpenChange, triggerRef } = useMobileLongPressTooltip()
+  return (
+    <button
+      ref={triggerRef}
+      type="button"
+      data-testid={id}
+      onMouseEnter={() => handleOpenChange(true)}
+      onMouseLeave={() => handleOpenChange(false)}
+    >
+      {open ? `${id}:open` : `${id}:closed`}
+    </button>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  resetTooltipScrollLockForTests()
+  vi.useRealTimers()
+})
+
+it('does not flash reopen after scroll-close while pointer still hovers the trigger', () => {
+  vi.useFakeTimers()
+  ensureTooltipScrollLockInstalled()
+  render(<DesktopCard id="a" />)
+  const trigger = screen.getByTestId('a')
+
+  act(() => {
+    fireEvent.mouseEnter(trigger)
+  })
+  expect(trigger.textContent).toBe('a:open')
+
+  Object.defineProperty(trigger, 'matches', {
+    configurable: true,
+    value: (selector: string) => selector === ':hover',
+  })
+
+  act(() => {
+    fireEvent.wheel(window)
+  })
+  expect(trigger.textContent).toBe('a:closed')
+
+  act(() => {
+    fireEvent.mouseEnter(trigger)
+  })
+  expect(trigger.textContent).toBe('a:closed')
+
+  Object.defineProperty(trigger, 'matches', {
+    configurable: true,
+    value: () => false,
+  })
+  act(() => {
+    fireEvent.mouseLeave(trigger)
+  })
+  act(() => {
+    vi.advanceTimersByTime(400)
+  })
+  act(() => {
+    Object.defineProperty(trigger, 'matches', {
+      configurable: true,
+      value: (selector: string) => selector === ':hover',
+    })
+    fireEvent.mouseEnter(trigger)
+  })
+  expect(trigger.textContent).toBe('a:open')
+})
+
+it('does not let a different card flash open under the cursor after scroll', () => {
+  vi.useFakeTimers()
+  ensureTooltipScrollLockInstalled()
+  render(
+    <>
+      <DesktopCard id="a" />
+      <DesktopCard id="b" />
+    </>,
+  )
+  const a = screen.getByTestId('a')
+  const b = screen.getByTestId('b')
+
+  act(() => {
+    fireEvent.mouseEnter(a)
+  })
+  expect(a.textContent).toBe('a:open')
+
+  // Capture-phase style: lock first (as window wheel would), then hover retargets to B.
+  act(() => {
+    lockTooltipsForScroll(400)
+    fireEvent.wheel(window)
+  })
+  expect(a.textContent).toBe('a:closed')
+
+  act(() => {
+    Object.defineProperty(b, 'matches', {
+      configurable: true,
+      value: (selector: string) => selector === ':hover',
+    })
+    fireEvent.mouseEnter(b)
+  })
+  expect(b.textContent).toBe('b:closed')
+
+  act(() => {
+    vi.advanceTimersByTime(400)
+  })
+  Object.defineProperty(b, 'matches', {
+    configurable: true,
+    value: () => false,
+  })
+  act(() => {
+    fireEvent.mouseLeave(b)
+  })
+  act(() => {
+    Object.defineProperty(b, 'matches', {
+      configurable: true,
+      value: (selector: string) => selector === ':hover',
+    })
+    fireEvent.mouseEnter(b)
+  })
+  expect(b.textContent).toBe('b:open')
+})
+
+it('force-closes any open card when global lock engages even without local wheel on that card', () => {
+  ensureTooltipScrollLockInstalled()
+  render(
+    <>
+      <DesktopCard id="a" />
+      <DesktopCard id="b" />
+    </>,
+  )
+  const a = screen.getByTestId('a')
+  const b = screen.getByTestId('b')
+
+  act(() => {
+    fireEvent.mouseEnter(a)
+  })
+  expect(a.textContent).toBe('a:open')
+
+  // B opens (group-instant simulation) then global lock fires — both must end closed.
+  act(() => {
+    fireEvent.mouseEnter(b)
+  })
+  // Without lock, B may open; then lock force-closes subscribers that are open.
+  act(() => {
+    lockTooltipsForScroll(400)
+  })
+  expect(a.textContent).toBe('a:closed')
+  expect(b.textContent).toBe('b:closed')
+})

--- a/src/hooks/use-mobile-long-press-tooltip.ts
+++ b/src/hooks/use-mobile-long-press-tooltip.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Dispatch, MouseEvent, MutableRefObject, PointerEvent, RefObject, SetStateAction } from 'react'
+import {
+  ensureTooltipScrollLockInstalled,
+  isTooltipScrollLocked,
+  lockTooltipsForScroll,
+  subscribeTooltipScrollClose,
+} from '@/lib/tooltip-scroll-lock'
 import { useIsMobile } from './use-mobile'
 import { useCloseOnScroll } from './use-close-on-scroll'
 
@@ -20,6 +26,15 @@ interface UseMobileLongPressTooltipReturn {
   isMobile: boolean
 }
 
+function isPointerOverTrigger(trigger: HTMLButtonElement | null): boolean {
+  if (!trigger) return false
+  try {
+    return trigger.matches(':hover') || document.activeElement === trigger
+  } catch {
+    return document.activeElement === trigger
+  }
+}
+
 /**
  * Shared hook for mobile long-press tooltip behavior.
  *
@@ -27,21 +42,44 @@ interface UseMobileLongPressTooltipReturn {
  * the user scrolls, taps elsewhere, or clicks the trigger again.
  * On desktop: standard hover/focus behavior via Base UI Tooltip.
  *
- * @param enabled - Whether the long-press tooltip is active (default: true).
- *                  When false on mobile, no pointer handlers are bound and
- *                  Base UI's default hover/focus behavior is restored.
+ * Scroll handling (desktop):
+ * - Capture-phase global lock blocks open on any card during/just after scroll
+ * - Open tooltips subscribe to force-close when the lock engages
+ * - Same-trigger suppress while pointer remains on a scroll-closed card
  */
 export function useMobileLongPressTooltip(
   enabled = true,
 ): UseMobileLongPressTooltipReturn {
   const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
-  const triggerRef = useCloseOnScroll(open, setOpen)
+  const suppressOpenRef = useRef(false)
+  const openRef = useRef(open)
+  openRef.current = open
+
+  useEffect(() => {
+    ensureTooltipScrollLockInstalled()
+  }, [])
+
+  // Force-close when any scroll/wheel is detected globally (capture phase).
+  useEffect(() => {
+    return subscribeTooltipScrollClose(() => {
+      if (!openRef.current) return
+      suppressOpenRef.current = true
+      setOpen(false)
+    })
+  }, [])
+
+  const closeFromScroll = useCallback(() => {
+    suppressOpenRef.current = true
+    lockTooltipsForScroll()
+    setOpen(false)
+  }, [])
+
+  const triggerRef = useCloseOnScroll(open, closeFromScroll)
 
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const longPressTriggeredRef = useRef(false)
   const pointerStartRef = useRef<{ x: number; y: number } | null>(null)
-  // True from pointerdown until pointerup/cancel — blocks Base UI close while finger is down
   const isPointerDownRef = useRef(false)
 
   const clearLongPress = useCallback(() => {
@@ -51,21 +89,40 @@ export function useMobileLongPressTooltip(
     }
   }, [])
 
-  // Clear long-press timer on unmount to prevent state updates on unmounted component
   useEffect(() => clearLongPress, [clearLongPress])
 
   const mobileEnabled = isMobile && enabled
 
-  // On mobile, prevent Base UI from auto-opening the tooltip (focus/hover),
-  // and block close requests while the user's finger is still down.
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     if (mobileEnabled) {
       if (!nextOpen && isPointerDownRef.current) return
       if (!nextOpen) setOpen(false)
       return
     }
-    setOpen(nextOpen)
-  }, [mobileEnabled])
+
+    if (nextOpen) {
+      if (isTooltipScrollLocked()) return
+      if (suppressOpenRef.current) {
+        if (isPointerOverTrigger(triggerRef.current)) return
+        suppressOpenRef.current = false
+      }
+      setOpen(true)
+      // Same-tick race: hover retarget may open B before/while scroll lock engages.
+      // Microtask re-check collapses any one-frame flash before paint when possible.
+      queueMicrotask(() => {
+        if (isTooltipScrollLocked()) {
+          suppressOpenRef.current = true
+          setOpen(false)
+        }
+      })
+      return
+    }
+
+    if (!isPointerOverTrigger(triggerRef.current)) {
+      suppressOpenRef.current = false
+    }
+    setOpen(false)
+  }, [mobileEnabled, triggerRef])
 
   const handlePointerDown = useCallback((e: PointerEvent) => {
     if (!mobileEnabled || e.pointerType !== 'touch' || !e.isPrimary) return
@@ -102,11 +159,6 @@ export function useMobileLongPressTooltip(
     e.preventDefault()
   }, [])
 
-  /**
-   * Call at the start of a click/toggle handler.
-   * Returns true if the click was a long-press release and should be swallowed.
-   * Also clears the longPressTriggered flag.
-   */
   const swallowLongPressClick = useCallback(() => {
     if (longPressTriggeredRef.current) {
       longPressTriggeredRef.current = false

--- a/src/hooks/use-mobile-long-press-tooltip.ts
+++ b/src/hooks/use-mobile-long-press-tooltip.ts
@@ -54,7 +54,10 @@ export function useMobileLongPressTooltip(
   const [open, setOpen] = useState(false)
   const suppressOpenRef = useRef(false)
   const openRef = useRef(open)
-  openRef.current = open
+
+  useEffect(() => {
+    openRef.current = open
+  }, [open])
 
   useEffect(() => {
     ensureTooltipScrollLockInstalled()

--- a/src/hooks/use-wiki-translations.test.tsx
+++ b/src/hooks/use-wiki-translations.test.tsx
@@ -9,8 +9,8 @@ vi.mock('next-intl', () => ({
   useLocale: () => 'zh-CN',
 }))
 
-vi.mock('@/lib/game-i18n-catalogs', () => {
-  const catalogs = {
+vi.mock('@/hooks/use-game-i18n-catalogs', () => ({
+  useGameI18nLocale: () => ({
     characters: { chr_test: '测试角色' },
     weapons: { wpn_test: '测试武器' },
     equips: { equip_test: '测试装备' },
@@ -21,17 +21,8 @@ vi.mock('@/lib/game-i18n-catalogs', () => {
       'suit|suit_test': '测试套装',
       'character|chr_test|skill|skill%2Etest|name': '带点号的技能',
     },
-  } as const
-
-  type Namespace = keyof typeof catalogs
-
-  return {
-    hasGameI18n: (locale: string, namespace: Namespace, key: string) =>
-      locale === 'zh-CN' && key in catalogs[namespace],
-    lookupGameI18n: (locale: string, namespace: Namespace, key: string) =>
-      locale === 'zh-CN' ? catalogs[namespace][key as keyof (typeof catalogs)[Namespace]] : undefined,
-  }
-})
+  }),
+}))
 
 const localized = (value: string) => ({ 'zh-CN': value, en: value, ja: value, 'zh-TW': value })
 
@@ -72,6 +63,7 @@ const equipment: WikiEquipmentSummary = {
 it('translates all wiki entity categories and falls back to missing IDs', () => {
   const { result } = renderHook(() => useWikiTranslations())
 
+  expect(result.current.ready).toBe(true)
   expect(result.current.entityName(character)).toBe('测试角色')
   expect(result.current.entityName(weapon)).toBe('测试武器')
   expect(result.current.entityName(equipment)).toBe('测试装备')

--- a/src/hooks/use-wiki-translations.test.tsx
+++ b/src/hooks/use-wiki-translations.test.tsx
@@ -5,29 +5,33 @@ import { expect, it, vi } from 'vitest'
 import { useWikiTranslations } from './use-wiki-translations'
 import type { WikiCharacterSummary, WikiEquipmentSummary, WikiWeaponSummary } from '@/types/wiki'
 
-const translations: Record<string, Record<string, string>> = {
-  characters: { chr_test: '测试角色' },
-  weapons: { wpn_test: '测试武器' },
-  equips: { equip_test: '测试装备' },
-  equipStats: { AllSkillDamageIncrease: '所有技能伤害加成' },
-  wikiData: {
-    'enum|attributes|39': '力量',
-    'item|item_test': '测试材料',
-    'suit|suit_test': '测试套装',
-    'character|chr_test|skill|skill%2Etest|name': '带点号的技能',
-  },
-}
-
 vi.mock('next-intl', () => ({
-  useTranslations: (namespace: string) => {
-    const values = translations[namespace] ?? {}
-    const translate = Object.assign((key: string) => values[key] ?? key, {
-      has: (key: string) => key in values,
-      raw: (key: string) => values[key] ?? key,
-    })
-    return translate
-  },
+  useLocale: () => 'zh-CN',
 }))
+
+vi.mock('@/lib/game-i18n-catalogs', () => {
+  const catalogs = {
+    characters: { chr_test: '测试角色' },
+    weapons: { wpn_test: '测试武器' },
+    equips: { equip_test: '测试装备' },
+    equipStats: { AllSkillDamageIncrease: '所有技能伤害加成' },
+    wikiData: {
+      'enum|attributes|39': '力量',
+      'item|item_test': '测试材料',
+      'suit|suit_test': '测试套装',
+      'character|chr_test|skill|skill%2Etest|name': '带点号的技能',
+    },
+  } as const
+
+  type Namespace = keyof typeof catalogs
+
+  return {
+    hasGameI18n: (locale: string, namespace: Namespace, key: string) =>
+      locale === 'zh-CN' && key in catalogs[namespace],
+    lookupGameI18n: (locale: string, namespace: Namespace, key: string) =>
+      locale === 'zh-CN' ? catalogs[namespace][key as keyof (typeof catalogs)[Namespace]] : undefined,
+  }
+})
 
 const localized = (value: string) => ({ 'zh-CN': value, en: value, ja: value, 'zh-TW': value })
 

--- a/src/hooks/use-wiki-translations.ts
+++ b/src/hooks/use-wiki-translations.ts
@@ -1,35 +1,52 @@
 'use client'
 
 import { useCallback } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale } from 'next-intl'
+import { hasGameI18n, lookupGameI18n } from '@/lib/game-i18n-catalogs'
 import { wikiTextKey } from '@/lib/wiki-i18n'
-import type { WikiEntitySummary, WikiEnumGroup } from '@/types/wiki'
+import type { WikiEntitySummary, WikiEnumGroup, WikiLocale } from '@/types/wiki'
 
+function asWikiLocale(locale: string): WikiLocale {
+  if (locale === 'en' || locale === 'ja' || locale === 'zh-CN' || locale === 'zh-TW') {
+    return locale
+  }
+  return 'zh-CN'
+}
+
+/**
+ * Wiki / planner entity labels resolved from generated catalogs (shared JS chunks).
+ * Does not read wikiData from NextIntlClientProvider — that would re-embed ~0.9MB
+ * into every static page under the root layout.
+ */
 export function useWikiTranslations() {
-  const characters = useTranslations('characters')
-  const weapons = useTranslations('weapons')
-  const equipment = useTranslations('equips')
-  const wikiData = useTranslations('wikiData')
-  const equipStats = useTranslations('equipStats')
+  const locale = asWikiLocale(useLocale())
 
   const entityName = useCallback((entity: WikiEntitySummary): string => {
-    if (entity.category === 'characters') return characters.has(entity.id) ? characters(entity.id) : entity.id
-    if (entity.category === 'weapons') return weapons.has(entity.id) ? weapons(entity.id) : entity.id
-    return equipment.has(entity.id) ? equipment(entity.id) : entity.id
-  }, [characters, equipment, weapons])
+    if (entity.category === 'characters') {
+      return lookupGameI18n(locale, 'characters', entity.id) ?? entity.id
+    }
+    if (entity.category === 'weapons') {
+      return lookupGameI18n(locale, 'weapons', entity.id) ?? entity.id
+    }
+    return lookupGameI18n(locale, 'equips', entity.id) ?? entity.id
+  }, [locale])
 
   const text = useCallback((...segments: Array<string | number>): string => {
     const key = wikiTextKey(...segments)
-    if (!wikiData.has(key)) return String(segments.at(-1) ?? key)
-    const value = wikiData.raw(key)
-    return typeof value === 'string' ? value : String(segments.at(-1) ?? key)
-  }, [wikiData])
+    return lookupGameI18n(locale, 'wikiData', key) ?? String(segments.at(-1) ?? key)
+  }, [locale])
 
-  const enumLabel = useCallback((group: WikiEnumGroup, id: string) => text('enum', group, id), [text])
+  const enumLabel = useCallback(
+    (group: WikiEnumGroup, id: string) => text('enum', group, id),
+    [text],
+  )
+
   const equipmentStatLabel = useCallback((id: string): string => {
-    if (equipStats.has(id)) return equipStats(id)
+    if (hasGameI18n(locale, 'equipStats', id)) {
+      return lookupGameI18n(locale, 'equipStats', id) ?? id
+    }
     return enumLabel('attributes', id)
-  }, [enumLabel, equipStats])
+  }, [enumLabel, locale])
 
   return {
     entityName,

--- a/src/hooks/use-wiki-translations.ts
+++ b/src/hooks/use-wiki-translations.ts
@@ -2,39 +2,34 @@
 
 import { useCallback } from 'react'
 import { useLocale } from 'next-intl'
-import { hasGameI18n, lookupGameI18n } from '@/lib/game-i18n-catalogs'
+import { useGameI18nLocale } from '@/hooks/use-game-i18n-catalogs'
+import { asWikiLocale } from '@/lib/wiki-locale'
 import { wikiTextKey } from '@/lib/wiki-i18n'
-import type { WikiEntitySummary, WikiEnumGroup, WikiLocale } from '@/types/wiki'
-
-function asWikiLocale(locale: string): WikiLocale {
-  if (locale === 'en' || locale === 'ja' || locale === 'zh-CN' || locale === 'zh-TW') {
-    return locale
-  }
-  return 'zh-CN'
-}
+import type { WikiEntitySummary, WikiEnumGroup } from '@/types/wiki'
 
 /**
- * Wiki / planner entity labels resolved from generated catalogs (shared JS chunks).
+ * Wiki / planner entity labels resolved from generated catalogs (per-locale chunks).
  * Does not read wikiData from NextIntlClientProvider — that would re-embed ~0.9MB
  * into every static page under the root layout.
  */
 export function useWikiTranslations() {
   const locale = asWikiLocale(useLocale())
+  const catalogs = useGameI18nLocale(locale)
 
   const entityName = useCallback((entity: WikiEntitySummary): string => {
     if (entity.category === 'characters') {
-      return lookupGameI18n(locale, 'characters', entity.id) ?? entity.id
+      return catalogs?.characters[entity.id] ?? entity.id
     }
     if (entity.category === 'weapons') {
-      return lookupGameI18n(locale, 'weapons', entity.id) ?? entity.id
+      return catalogs?.weapons[entity.id] ?? entity.id
     }
-    return lookupGameI18n(locale, 'equips', entity.id) ?? entity.id
-  }, [locale])
+    return catalogs?.equips[entity.id] ?? entity.id
+  }, [catalogs])
 
   const text = useCallback((...segments: Array<string | number>): string => {
     const key = wikiTextKey(...segments)
-    return lookupGameI18n(locale, 'wikiData', key) ?? String(segments.at(-1) ?? key)
-  }, [locale])
+    return catalogs?.wikiData[key] ?? String(segments.at(-1) ?? key)
+  }, [catalogs])
 
   const enumLabel = useCallback(
     (group: WikiEnumGroup, id: string) => text('enum', group, id),
@@ -42,11 +37,9 @@ export function useWikiTranslations() {
   )
 
   const equipmentStatLabel = useCallback((id: string): string => {
-    if (hasGameI18n(locale, 'equipStats', id)) {
-      return lookupGameI18n(locale, 'equipStats', id) ?? id
-    }
+    if (catalogs?.equipStats[id]) return catalogs.equipStats[id]
     return enumLabel('attributes', id)
-  }, [enumLabel, locale])
+  }, [catalogs, enumLabel])
 
   return {
     entityName,
@@ -55,5 +48,7 @@ export function useWikiTranslations() {
     itemName: (itemId: string) => text('item', itemId),
     suitName: (suitId: string) => text('suit', suitId),
     text,
+    /** True once the locale catalog chunk has loaded. */
+    ready: catalogs != null,
   }
 }

--- a/src/i18n/load-messages.test.ts
+++ b/src/i18n/load-messages.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from 'vitest'
+import { loadClientMessages, loadMessages } from './load-messages'
+
+it('client messages omit wikiData for every locale', () => {
+  for (const locale of ['zh-CN', 'zh-TW', 'ja', 'en'] as const) {
+    const messages = loadClientMessages(locale) as Record<string, unknown>
+    expect(messages).not.toHaveProperty('wikiData')
+    expect(messages).toHaveProperty('nav')
+    expect(messages).toHaveProperty('weapons')
+  }
+})
+
+it('server messages include wikiData for the selected locale', () => {
+  const en = loadMessages('en') as Record<string, unknown>
+  expect(en).toHaveProperty('wikiData')
+  expect(en.wikiData).toBeTruthy()
+  expect(typeof en.wikiData).toBe('object')
+  expect(Object.keys(en.wikiData as object).length).toBeGreaterThan(100)
+
+  const zh = loadMessages('zh-CN') as Record<string, unknown>
+  expect(zh).toHaveProperty('wikiData')
+  // Different locale catalogs are distinct objects (not accidentally sharing client-only bags).
+  expect(zh.wikiData).not.toBe(en.wikiData)
+})

--- a/src/i18n/load-messages.ts
+++ b/src/i18n/load-messages.ts
@@ -52,13 +52,104 @@ import wikiDataZhCN from '@/generated/i18n/wikiData/zh-CN.json'
 import wikiDataZhTW from '@/generated/i18n/wikiData/zh-TW.json'
 import type { WikiLocale } from '@/types/wiki'
 
-const messages = {
-  'zh-CN': { ...zhCN, characters: charactersZhCN, dungeons: dungeonsZhCN, equipStats: equipStatsZhCN, equipTypes: equipTypesZhCN, equips: equipsZhCN, gemStats: gemStatsZhCN, materials: materialsZhCN, region: regionsZhCN, suits: suitsZhCN, weapons: weaponsZhCN, weaponStats: weaponStatsZhCN, wikiData: wikiDataZhCN },
-  'zh-TW': { ...zhTW, characters: charactersZhTW, dungeons: dungeonsZhTW, equipStats: equipStatsZhTW, equipTypes: equipTypesZhTW, equips: equipsZhTW, gemStats: gemStatsZhTW, materials: materialsZhTW, region: regionsZhTW, suits: suitsZhTW, weapons: weaponsZhTW, weaponStats: weaponStatsZhTW, wikiData: wikiDataZhTW },
-  ja: { ...ja, characters: charactersJa, dungeons: dungeonsJa, equipStats: equipStatsJa, equipTypes: equipTypesJa, equips: equipsJa, gemStats: gemStatsJa, materials: materialsJa, region: regionsJa, suits: suitsJa, weapons: weaponsJa, weaponStats: weaponStatsJa, wikiData: wikiDataJa },
-  en: { ...en, characters: charactersEn, dungeons: dungeonsEn, equipStats: equipStatsEn, equipTypes: equipTypesEn, equips: equipsEn, gemStats: gemStatsEn, materials: materialsEn, region: regionsEn, suits: suitsEn, weapons: weaponsEn, weaponStats: weaponStatsEn, wikiData: wikiDataEn },
+/** Hand-written UI strings only. */
+const shellMessages = {
+  'zh-CN': zhCN,
+  'zh-TW': zhTW,
+  ja,
+  en,
 } satisfies Record<WikiLocale, object>
 
+/**
+ * Short generated name tables used by client planners via useTranslations.
+ * Intentionally excludes wikiData (~0.9MB) which is loaded via game-i18n-catalogs
+ * so static export does not embed it in every page's RSC payload.
+ */
+const plannerCatalogs = {
+  'zh-CN': {
+    characters: charactersZhCN,
+    dungeons: dungeonsZhCN,
+    equipStats: equipStatsZhCN,
+    equipTypes: equipTypesZhCN,
+    equips: equipsZhCN,
+    gemStats: gemStatsZhCN,
+    materials: materialsZhCN,
+    region: regionsZhCN,
+    suits: suitsZhCN,
+    weapons: weaponsZhCN,
+    weaponStats: weaponStatsZhCN,
+  },
+  'zh-TW': {
+    characters: charactersZhTW,
+    dungeons: dungeonsZhTW,
+    equipStats: equipStatsZhTW,
+    equipTypes: equipTypesZhTW,
+    equips: equipsZhTW,
+    gemStats: gemStatsZhTW,
+    materials: materialsZhTW,
+    region: regionsZhTW,
+    suits: suitsZhTW,
+    weapons: weaponsZhTW,
+    weaponStats: weaponStatsZhTW,
+  },
+  ja: {
+    characters: charactersJa,
+    dungeons: dungeonsJa,
+    equipStats: equipStatsJa,
+    equipTypes: equipTypesJa,
+    equips: equipsJa,
+    gemStats: gemStatsJa,
+    materials: materialsJa,
+    region: regionsJa,
+    suits: suitsJa,
+    weapons: weaponsJa,
+    weaponStats: weaponStatsJa,
+  },
+  en: {
+    characters: charactersEn,
+    dungeons: dungeonsEn,
+    equipStats: equipStatsEn,
+    equipTypes: equipTypesEn,
+    equips: equipsEn,
+    gemStats: gemStatsEn,
+    materials: materialsEn,
+    region: regionsEn,
+    suits: suitsEn,
+    weapons: weaponsEn,
+    weaponStats: weaponStatsEn,
+  },
+} satisfies Record<WikiLocale, object>
+
+const wikiDataCatalogs = {
+  'zh-CN': wikiDataZhCN,
+  'zh-TW': wikiDataZhTW,
+  ja: wikiDataJa,
+  en: wikiDataEn,
+} satisfies Record<WikiLocale, object>
+
+/**
+ * Messages for NextIntlClientProvider (client runtime / static HTML payload).
+ * Includes UI + short planner catalogs. Does NOT include wikiData.
+ */
+export function loadClientMessages(locale: WikiLocale) {
+  return {
+    ...shellMessages[locale],
+    ...plannerCatalogs[locale],
+  }
+}
+
+/**
+ * Full messages for server-side getTranslations / getRequestConfig during SSG.
+ * Includes wikiData so wiki pages can resolve long-form text at build time.
+ */
 export function loadMessages(locale: WikiLocale) {
-  return messages[locale]
+  return {
+    ...loadClientMessages(locale),
+    wikiData: wikiDataCatalogs[locale],
+  }
+}
+
+/** @deprecated Use loadClientMessages for ClientProvider, loadMessages for server. */
+export function loadShellMessages(locale: WikiLocale) {
+  return shellMessages[locale]
 }

--- a/src/i18n/load-messages.ts
+++ b/src/i18n/load-messages.ts
@@ -62,7 +62,7 @@ const shellMessages = {
 
 /**
  * Short generated name tables used by client planners via useTranslations.
- * Intentionally excludes wikiData (~0.9MB) which is loaded via game-i18n-catalogs
+ * Intentionally excludes wikiData (~0.9MB) which is loaded per-locale via game-i18n-catalogs dynamic import
  * so static export does not embed it in every page's RSC payload.
  */
 const plannerCatalogs = {

--- a/src/lib/game-i18n-catalogs.test.ts
+++ b/src/lib/game-i18n-catalogs.test.ts
@@ -1,0 +1,14 @@
+import { expect, it } from 'vitest'
+import { hasGameI18n, lookupGameI18n, getGameI18nCatalog } from './game-i18n-catalogs'
+
+it('loads generated catalogs for supported locales', () => {
+  const catalog = getGameI18nCatalog('en', 'wikiData')
+  expect(Object.keys(catalog).length).toBeGreaterThan(100)
+  expect(hasGameI18n('en', 'wikiData', 'enum|attributes|0')).toBe(true)
+  expect(lookupGameI18n('en', 'wikiData', 'enum|attributes|0')).toBeTruthy()
+})
+
+it('returns undefined for missing keys without throwing', () => {
+  expect(hasGameI18n('zh-CN', 'characters', 'definitely-missing-id')).toBe(false)
+  expect(lookupGameI18n('zh-CN', 'characters', 'definitely-missing-id')).toBeUndefined()
+})

--- a/src/lib/game-i18n-catalogs.test.ts
+++ b/src/lib/game-i18n-catalogs.test.ts
@@ -1,14 +1,36 @@
-import { expect, it } from 'vitest'
-import { hasGameI18n, lookupGameI18n, getGameI18nCatalog } from './game-i18n-catalogs'
+import { afterEach, expect, it } from 'vitest'
+import {
+  getCachedGameI18nLocale,
+  hasGameI18n,
+  loadGameI18nLocale,
+  lookupGameI18n,
+  resetGameI18nCatalogCacheForTests,
+} from './game-i18n-catalogs'
 
-it('loads generated catalogs for supported locales', () => {
-  const catalog = getGameI18nCatalog('en', 'wikiData')
-  expect(Object.keys(catalog).length).toBeGreaterThan(100)
-  expect(hasGameI18n('en', 'wikiData', 'enum|attributes|0')).toBe(true)
-  expect(lookupGameI18n('en', 'wikiData', 'enum|attributes|0')).toBeTruthy()
+afterEach(() => {
+  resetGameI18nCatalogCacheForTests()
 })
 
-it('returns undefined for missing keys without throwing', () => {
+it('loads a single locale bundle and caches it', async () => {
+  expect(getCachedGameI18nLocale('en')).toBeUndefined()
+  const bundle = await loadGameI18nLocale('en')
+  expect(Object.keys(bundle.wikiData).length).toBeGreaterThan(100)
+  expect(getCachedGameI18nLocale('en')).toBe(bundle)
+  expect(hasGameI18n('en', 'wikiData', 'enum|attributes|0')).toBe(true)
+  expect(lookupGameI18n('en', 'wikiData', 'enum|attributes|0')).toBeTruthy()
+  // Second call hits cache
+  await expect(loadGameI18nLocale('en')).resolves.toBe(bundle)
+})
+
+it('returns undefined for missing keys without throwing', async () => {
+  await loadGameI18nLocale('zh-CN')
   expect(hasGameI18n('zh-CN', 'characters', 'definitely-missing-id')).toBe(false)
   expect(lookupGameI18n('zh-CN', 'characters', 'definitely-missing-id')).toBeUndefined()
+})
+
+it('does not load other locales when one locale is requested', async () => {
+  await loadGameI18nLocale('ja')
+  expect(getCachedGameI18nLocale('ja')).toBeTruthy()
+  expect(getCachedGameI18nLocale('en')).toBeUndefined()
+  expect(getCachedGameI18nLocale('zh-CN')).toBeUndefined()
 })

--- a/src/lib/game-i18n-catalogs.ts
+++ b/src/lib/game-i18n-catalogs.ts
@@ -3,33 +3,15 @@
  *
  * Long-form wiki text (wikiData) must NOT go through NextIntlClientProvider:
  * static export serializes provider messages into every page HTML/RSC payload.
- * These imports land in shared JS chunks instead (one copy site-wide).
+ *
+ * Catalogs are loaded per locale via dynamic import() so unused locales stay out
+ * of the initial client bundle. Results are cached and frozen (read-only).
  *
  * Full catalogs remain available to the server via loadMessages() for SSG.
  */
-import charactersEn from '@/generated/i18n/characters/en.json'
-import charactersJa from '@/generated/i18n/characters/ja.json'
-import charactersZhCN from '@/generated/i18n/characters/zh-CN.json'
-import charactersZhTW from '@/generated/i18n/characters/zh-TW.json'
-import equipsEn from '@/generated/i18n/equips/en.json'
-import equipsJa from '@/generated/i18n/equips/ja.json'
-import equipsZhCN from '@/generated/i18n/equips/zh-CN.json'
-import equipsZhTW from '@/generated/i18n/equips/zh-TW.json'
-import equipStatsEn from '@/generated/i18n/equipStats/en.json'
-import equipStatsJa from '@/generated/i18n/equipStats/ja.json'
-import equipStatsZhCN from '@/generated/i18n/equipStats/zh-CN.json'
-import equipStatsZhTW from '@/generated/i18n/equipStats/zh-TW.json'
-import weaponsEn from '@/generated/i18n/weapons/en.json'
-import weaponsJa from '@/generated/i18n/weapons/ja.json'
-import weaponsZhCN from '@/generated/i18n/weapons/zh-CN.json'
-import weaponsZhTW from '@/generated/i18n/weapons/zh-TW.json'
-import wikiDataEn from '@/generated/i18n/wikiData/en.json'
-import wikiDataJa from '@/generated/i18n/wikiData/ja.json'
-import wikiDataZhCN from '@/generated/i18n/wikiData/zh-CN.json'
-import wikiDataZhTW from '@/generated/i18n/wikiData/zh-TW.json'
 import type { WikiLocale } from '@/types/wiki'
 
-type StringCatalog = Record<string, string>
+export type StringCatalog = Record<string, string>
 
 export type GameI18nNamespace =
   | 'characters'
@@ -38,44 +20,135 @@ export type GameI18nNamespace =
   | 'equipStats'
   | 'wikiData'
 
-const catalogs: Record<GameI18nNamespace, Record<WikiLocale, StringCatalog>> = {
-  characters: {
-    en: charactersEn,
-    ja: charactersJa,
-    'zh-CN': charactersZhCN,
-    'zh-TW': charactersZhTW,
-  },
-  weapons: {
-    en: weaponsEn,
-    ja: weaponsJa,
-    'zh-CN': weaponsZhCN,
-    'zh-TW': weaponsZhTW,
-  },
-  equips: {
-    en: equipsEn,
-    ja: equipsJa,
-    'zh-CN': equipsZhCN,
-    'zh-TW': equipsZhTW,
-  },
-  equipStats: {
-    en: equipStatsEn,
-    ja: equipStatsJa,
-    'zh-CN': equipStatsZhCN,
-    'zh-TW': equipStatsZhTW,
-  },
-  wikiData: {
-    en: wikiDataEn,
-    ja: wikiDataJa,
-    'zh-CN': wikiDataZhCN,
-    'zh-TW': wikiDataZhTW,
-  },
+export type GameI18nLocaleBundle = Record<GameI18nNamespace, StringCatalog>
+
+const cache = new Map<WikiLocale, GameI18nLocaleBundle>()
+const inflight = new Map<WikiLocale, Promise<GameI18nLocaleBundle>>()
+
+function freezeBundle(bundle: GameI18nLocaleBundle): GameI18nLocaleBundle {
+  for (const key of Object.keys(bundle) as GameI18nNamespace[]) {
+    Object.freeze(bundle[key])
+  }
+  return Object.freeze(bundle)
 }
 
+function unwrapJsonModule(mod: { default: StringCatalog } | StringCatalog): StringCatalog {
+  if (mod && typeof mod === 'object' && 'default' in mod) {
+    return (mod as { default: StringCatalog }).default
+  }
+  return mod as StringCatalog
+}
+
+/**
+ * Explicit switch so the bundler emits one async chunk group per locale
+ * (not a single mega-chunk with all languages).
+ */
+async function importLocaleBundle(locale: WikiLocale): Promise<GameI18nLocaleBundle> {
+  switch (locale) {
+    case 'en': {
+      const [characters, weapons, equips, equipStats, wikiData] = await Promise.all([
+        import('@/generated/i18n/characters/en.json'),
+        import('@/generated/i18n/weapons/en.json'),
+        import('@/generated/i18n/equips/en.json'),
+        import('@/generated/i18n/equipStats/en.json'),
+        import('@/generated/i18n/wikiData/en.json'),
+      ])
+      return freezeBundle({
+        characters: unwrapJsonModule(characters),
+        weapons: unwrapJsonModule(weapons),
+        equips: unwrapJsonModule(equips),
+        equipStats: unwrapJsonModule(equipStats),
+        wikiData: unwrapJsonModule(wikiData),
+      })
+    }
+    case 'ja': {
+      const [characters, weapons, equips, equipStats, wikiData] = await Promise.all([
+        import('@/generated/i18n/characters/ja.json'),
+        import('@/generated/i18n/weapons/ja.json'),
+        import('@/generated/i18n/equips/ja.json'),
+        import('@/generated/i18n/equipStats/ja.json'),
+        import('@/generated/i18n/wikiData/ja.json'),
+      ])
+      return freezeBundle({
+        characters: unwrapJsonModule(characters),
+        weapons: unwrapJsonModule(weapons),
+        equips: unwrapJsonModule(equips),
+        equipStats: unwrapJsonModule(equipStats),
+        wikiData: unwrapJsonModule(wikiData),
+      })
+    }
+    case 'zh-TW': {
+      const [characters, weapons, equips, equipStats, wikiData] = await Promise.all([
+        import('@/generated/i18n/characters/zh-TW.json'),
+        import('@/generated/i18n/weapons/zh-TW.json'),
+        import('@/generated/i18n/equips/zh-TW.json'),
+        import('@/generated/i18n/equipStats/zh-TW.json'),
+        import('@/generated/i18n/wikiData/zh-TW.json'),
+      ])
+      return freezeBundle({
+        characters: unwrapJsonModule(characters),
+        weapons: unwrapJsonModule(weapons),
+        equips: unwrapJsonModule(equips),
+        equipStats: unwrapJsonModule(equipStats),
+        wikiData: unwrapJsonModule(wikiData),
+      })
+    }
+    case 'zh-CN':
+    default: {
+      const [characters, weapons, equips, equipStats, wikiData] = await Promise.all([
+        import('@/generated/i18n/characters/zh-CN.json'),
+        import('@/generated/i18n/weapons/zh-CN.json'),
+        import('@/generated/i18n/equips/zh-CN.json'),
+        import('@/generated/i18n/equipStats/zh-CN.json'),
+        import('@/generated/i18n/wikiData/zh-CN.json'),
+      ])
+      return freezeBundle({
+        characters: unwrapJsonModule(characters),
+        weapons: unwrapJsonModule(weapons),
+        equips: unwrapJsonModule(equips),
+        equipStats: unwrapJsonModule(equipStats),
+        wikiData: unwrapJsonModule(wikiData),
+      })
+    }
+  }
+}
+
+/** Sync read of an already-loaded locale bundle (undefined until loaded). */
+export function getCachedGameI18nLocale(locale: WikiLocale): GameI18nLocaleBundle | undefined {
+  return cache.get(locale)
+}
+
+/** Load (or return cached) catalogs for one locale. Safe to call repeatedly. */
+export function loadGameI18nLocale(locale: WikiLocale): Promise<GameI18nLocaleBundle> {
+  const cached = cache.get(locale)
+  if (cached) return Promise.resolve(cached)
+
+  let pending = inflight.get(locale)
+  if (!pending) {
+    pending = importLocaleBundle(locale)
+      .then((bundle) => {
+        cache.set(locale, bundle)
+        inflight.delete(locale)
+        return bundle
+      })
+      .catch((error: unknown) => {
+        inflight.delete(locale)
+        throw error
+      })
+    inflight.set(locale, pending)
+  }
+  return pending
+}
+
+/**
+ * Shared frozen catalog for locale/namespace when already loaded.
+ * Returns empty object if locale not yet loaded (callers should prefer the hook).
+ */
 export function getGameI18nCatalog(
   locale: WikiLocale,
   namespace: GameI18nNamespace,
 ): StringCatalog {
-  return catalogs[namespace][locale]
+  return cache.get(locale)?.[namespace] ?? Object.freeze({})
 }
 
 export function lookupGameI18n(
@@ -83,7 +156,7 @@ export function lookupGameI18n(
   namespace: GameI18nNamespace,
   key: string,
 ): string | undefined {
-  const value = catalogs[namespace][locale][key]
+  const value = cache.get(locale)?.[namespace]?.[key]
   return typeof value === 'string' ? value : undefined
 }
 
@@ -92,5 +165,11 @@ export function hasGameI18n(
   namespace: GameI18nNamespace,
   key: string,
 ): boolean {
-  return typeof catalogs[namespace][locale][key] === 'string'
+  return typeof cache.get(locale)?.[namespace]?.[key] === 'string'
+}
+
+/** Test helper */
+export function resetGameI18nCatalogCacheForTests(): void {
+  cache.clear()
+  inflight.clear()
 }

--- a/src/lib/game-i18n-catalogs.ts
+++ b/src/lib/game-i18n-catalogs.ts
@@ -1,0 +1,96 @@
+/**
+ * Generated game i18n catalogs for client-side lookup.
+ *
+ * Long-form wiki text (wikiData) must NOT go through NextIntlClientProvider:
+ * static export serializes provider messages into every page HTML/RSC payload.
+ * These imports land in shared JS chunks instead (one copy site-wide).
+ *
+ * Full catalogs remain available to the server via loadMessages() for SSG.
+ */
+import charactersEn from '@/generated/i18n/characters/en.json'
+import charactersJa from '@/generated/i18n/characters/ja.json'
+import charactersZhCN from '@/generated/i18n/characters/zh-CN.json'
+import charactersZhTW from '@/generated/i18n/characters/zh-TW.json'
+import equipsEn from '@/generated/i18n/equips/en.json'
+import equipsJa from '@/generated/i18n/equips/ja.json'
+import equipsZhCN from '@/generated/i18n/equips/zh-CN.json'
+import equipsZhTW from '@/generated/i18n/equips/zh-TW.json'
+import equipStatsEn from '@/generated/i18n/equipStats/en.json'
+import equipStatsJa from '@/generated/i18n/equipStats/ja.json'
+import equipStatsZhCN from '@/generated/i18n/equipStats/zh-CN.json'
+import equipStatsZhTW from '@/generated/i18n/equipStats/zh-TW.json'
+import weaponsEn from '@/generated/i18n/weapons/en.json'
+import weaponsJa from '@/generated/i18n/weapons/ja.json'
+import weaponsZhCN from '@/generated/i18n/weapons/zh-CN.json'
+import weaponsZhTW from '@/generated/i18n/weapons/zh-TW.json'
+import wikiDataEn from '@/generated/i18n/wikiData/en.json'
+import wikiDataJa from '@/generated/i18n/wikiData/ja.json'
+import wikiDataZhCN from '@/generated/i18n/wikiData/zh-CN.json'
+import wikiDataZhTW from '@/generated/i18n/wikiData/zh-TW.json'
+import type { WikiLocale } from '@/types/wiki'
+
+type StringCatalog = Record<string, string>
+
+export type GameI18nNamespace =
+  | 'characters'
+  | 'weapons'
+  | 'equips'
+  | 'equipStats'
+  | 'wikiData'
+
+const catalogs: Record<GameI18nNamespace, Record<WikiLocale, StringCatalog>> = {
+  characters: {
+    en: charactersEn,
+    ja: charactersJa,
+    'zh-CN': charactersZhCN,
+    'zh-TW': charactersZhTW,
+  },
+  weapons: {
+    en: weaponsEn,
+    ja: weaponsJa,
+    'zh-CN': weaponsZhCN,
+    'zh-TW': weaponsZhTW,
+  },
+  equips: {
+    en: equipsEn,
+    ja: equipsJa,
+    'zh-CN': equipsZhCN,
+    'zh-TW': equipsZhTW,
+  },
+  equipStats: {
+    en: equipStatsEn,
+    ja: equipStatsJa,
+    'zh-CN': equipStatsZhCN,
+    'zh-TW': equipStatsZhTW,
+  },
+  wikiData: {
+    en: wikiDataEn,
+    ja: wikiDataJa,
+    'zh-CN': wikiDataZhCN,
+    'zh-TW': wikiDataZhTW,
+  },
+}
+
+export function getGameI18nCatalog(
+  locale: WikiLocale,
+  namespace: GameI18nNamespace,
+): StringCatalog {
+  return catalogs[namespace][locale]
+}
+
+export function lookupGameI18n(
+  locale: WikiLocale,
+  namespace: GameI18nNamespace,
+  key: string,
+): string | undefined {
+  const value = catalogs[namespace][locale][key]
+  return typeof value === 'string' ? value : undefined
+}
+
+export function hasGameI18n(
+  locale: WikiLocale,
+  namespace: GameI18nNamespace,
+  key: string,
+): boolean {
+  return typeof catalogs[namespace][locale][key] === 'string'
+}

--- a/src/lib/tooltip-scroll-lock.test.ts
+++ b/src/lib/tooltip-scroll-lock.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import {
+  isTooltipScrollLocked,
+  lockTooltipsForScroll,
+  resetTooltipScrollLockForTests,
+  subscribeTooltipScrollClose,
+} from './tooltip-scroll-lock'
+
+afterEach(() => {
+  resetTooltipScrollLockForTests()
+  vi.useRealTimers()
+})
+
+it('locks immediately and unlocks after the debounce window', () => {
+  vi.useFakeTimers()
+  expect(isTooltipScrollLocked()).toBe(false)
+  lockTooltipsForScroll(200)
+  expect(isTooltipScrollLocked()).toBe(true)
+  vi.advanceTimersByTime(199)
+  expect(isTooltipScrollLocked()).toBe(true)
+  vi.advanceTimersByTime(1)
+  expect(isTooltipScrollLocked()).toBe(false)
+})
+
+it('extends the lock when scroll keeps firing', () => {
+  vi.useFakeTimers()
+  lockTooltipsForScroll(200)
+  vi.advanceTimersByTime(150)
+  lockTooltipsForScroll(200)
+  vi.advanceTimersByTime(150)
+  expect(isTooltipScrollLocked()).toBe(true)
+  vi.advanceTimersByTime(50)
+  expect(isTooltipScrollLocked()).toBe(false)
+})
+
+it('notifies close subscribers on every lock engagement', () => {
+  const onClose = vi.fn()
+  const unsubscribe = subscribeTooltipScrollClose(onClose)
+  lockTooltipsForScroll(200)
+  lockTooltipsForScroll(200)
+  expect(onClose).toHaveBeenCalledTimes(2)
+  unsubscribe()
+  lockTooltipsForScroll(200)
+  expect(onClose).toHaveBeenCalledTimes(2)
+})

--- a/src/lib/tooltip-scroll-lock.test.ts
+++ b/src/lib/tooltip-scroll-lock.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment jsdom
+
 import { afterEach, expect, it, vi } from 'vitest'
 import {
+  ensureTooltipScrollLockInstalled,
   isTooltipScrollLocked,
   lockTooltipsForScroll,
   resetTooltipScrollLockForTests,
@@ -42,4 +45,27 @@ it('notifies close subscribers on every lock engagement', () => {
   unsubscribe()
   lockTooltipsForScroll(200)
   expect(onClose).toHaveBeenCalledTimes(2)
+})
+
+it('does not global-lock when wheel targets tooltip content after install', () => {
+  ensureTooltipScrollLockInstalled()
+  const tip = document.createElement('div')
+  tip.setAttribute('data-slot', 'tooltip-content')
+  tip.textContent = 'preview'
+  document.body.appendChild(tip)
+
+  const inside = new WheelEvent('wheel', { bubbles: true, cancelable: true })
+  Object.defineProperty(inside, 'target', { value: tip })
+  window.dispatchEvent(inside)
+  expect(isTooltipScrollLocked()).toBe(false)
+
+  const outside = document.createElement('div')
+  document.body.appendChild(outside)
+  const outsideEvent = new WheelEvent('wheel', { bubbles: true, cancelable: true })
+  Object.defineProperty(outsideEvent, 'target', { value: outside })
+  window.dispatchEvent(outsideEvent)
+  expect(isTooltipScrollLocked()).toBe(true)
+
+  tip.remove()
+  outside.remove()
 })

--- a/src/lib/tooltip-scroll-lock.ts
+++ b/src/lib/tooltip-scroll-lock.ts
@@ -1,0 +1,87 @@
+/**
+ * Global scroll lock for controlled tooltips.
+ *
+ * Per-trigger suppress only covers the card that was open when scroll started.
+ * After scrolling, the pointer often sits on a *different* card — that instance
+ * would instantly re-open (Base UI group timeout) and flash.
+ *
+ * Strategy:
+ * 1. Capture-phase window listeners lock on every wheel/scroll (before hover
+ *    retargeting opens another card).
+ * 2. Subscribers (open tooltips) force-close when the lock engages.
+ * 3. While locked, handleOpenChange(true) is ignored.
+ */
+
+const CLEAR_AFTER_MS = 400
+
+let locked = false
+let clearTimer: ReturnType<typeof setTimeout> | null = null
+let installed = false
+const closeListeners = new Set<() => void>()
+
+function scheduleUnlock(durationMs: number): void {
+  if (clearTimer) clearTimeout(clearTimer)
+  clearTimer = setTimeout(() => {
+    locked = false
+    clearTimer = null
+  }, durationMs)
+}
+
+/**
+ * Engage the lock and notify subscribers to close. Safe to call often —
+ * each call extends the unlock debounce.
+ */
+export function lockTooltipsForScroll(durationMs = CLEAR_AFTER_MS): void {
+  const wasLocked = locked
+  locked = true
+  scheduleUnlock(durationMs)
+  // Always notify so any tip that opened in the same frame also closes.
+  // First lock + subsequent scroll ticks both force-close.
+  if (!wasLocked || closeListeners.size > 0) {
+    closeListeners.forEach((listener) => {
+      try {
+        listener()
+      } catch {
+        // ignore subscriber errors
+      }
+    })
+  }
+}
+
+export function isTooltipScrollLocked(): boolean {
+  return locked
+}
+
+/** Open tooltips register a close callback for capture-phase scroll lock. */
+export function subscribeTooltipScrollClose(onClose: () => void): () => void {
+  closeListeners.add(onClose)
+  return () => {
+    closeListeners.delete(onClose)
+  }
+}
+
+/**
+ * Install once at module load (client). Capture phase runs before target
+ * hover retargeting so a new card under the cursor cannot flash open.
+ */
+export function ensureTooltipScrollLockInstalled(): void {
+  if (installed || typeof window === 'undefined') return
+  installed = true
+  const onScrollIntent = () => {
+    lockTooltipsForScroll()
+  }
+  window.addEventListener('wheel', onScrollIntent, { capture: true, passive: true })
+  window.addEventListener('scroll', onScrollIntent, { capture: true, passive: true })
+  document.addEventListener('scroll', onScrollIntent, { capture: true, passive: true })
+}
+
+/** Test helper — resets module state between cases. */
+export function resetTooltipScrollLockForTests(): void {
+  locked = false
+  if (clearTimer) {
+    clearTimeout(clearTimer)
+    clearTimer = null
+  }
+  closeListeners.clear()
+  // Do not flip `installed` — listeners stay for the jsdom session.
+}

--- a/src/lib/tooltip-scroll-lock.ts
+++ b/src/lib/tooltip-scroll-lock.ts
@@ -67,7 +67,12 @@ export function subscribeTooltipScrollClose(onClose: () => void): () => void {
 export function ensureTooltipScrollLockInstalled(): void {
   if (installed || typeof window === 'undefined') return
   installed = true
-  const onScrollIntent = () => {
+  const onScrollIntent = (event: Event) => {
+    const target = event.target
+    // Long planner previews scroll inside the popup; do not lock/close for that.
+    if (target instanceof Element && target.closest('[data-slot="tooltip-content"]')) return
+    // Some browsers target Document/Text for wheel; walk to parent Element when needed.
+    if (target instanceof Text && target.parentElement?.closest('[data-slot="tooltip-content"]')) return
     lockTooltipsForScroll()
   }
   window.addEventListener('wheel', onScrollIntent, { capture: true, passive: true })

--- a/src/lib/wiki-locale.test.ts
+++ b/src/lib/wiki-locale.test.ts
@@ -1,0 +1,16 @@
+import { expect, it } from 'vitest'
+import { asWikiLocale } from './wiki-locale'
+
+it('accepts supported locales unchanged', () => {
+  expect(asWikiLocale('en')).toBe('en')
+  expect(asWikiLocale('ja')).toBe('ja')
+  expect(asWikiLocale('zh-CN')).toBe('zh-CN')
+  expect(asWikiLocale('zh-TW')).toBe('zh-TW')
+})
+
+it('falls back unknown locales to zh-CN', () => {
+  expect(asWikiLocale('fr')).toBe('zh-CN')
+  expect(asWikiLocale('')).toBe('zh-CN')
+  expect(asWikiLocale('zh')).toBe('zh-CN')
+  expect(asWikiLocale('EN')).toBe('zh-CN')
+})

--- a/src/lib/wiki-locale.ts
+++ b/src/lib/wiki-locale.ts
@@ -1,0 +1,9 @@
+import type { WikiLocale } from '@/types/wiki'
+
+/** Normalize next-intl locale strings to project WikiLocale (fallback zh-CN). */
+export function asWikiLocale(locale: string): WikiLocale {
+  if (locale === 'en' || locale === 'ja' || locale === 'zh-CN' || locale === 'zh-TW') {
+    return locale
+  }
+  return 'zh-CN'
+}


### PR DESCRIPTION
## Summary by Sourcery

将 wiki/game 的 i18n 加载拆分为轻量级的客户端消息和完整的服务端目录，并重构规划器工具提示和滚动行为，以避免大体积负载和工具提示闪烁。

New Features:
- 引入独立的 `loadClientMessages` 和 `loadMessages` 辅助函数，以区分用于客户端 UI 的目录和服务端使用的完整 `wikiData`。
- 新增共享的 `PlannerPreviewTooltip` 组件，为规划器和 wiki 实体卡片提供统一的桌面端悬停预览和移动端长按预览。
- 暴露 `game-i18n-catalogs` 模块，用于在客户端查找生成的 wiki 和实体文案，而不会膨胀 NextIntl 的客户端 messages。

Enhancements:
- 更新 wiki 翻译与富文本 hooks，使其通过共享的 game i18n 目录解析标签，而不是使用 NextIntl 的 `wikiData` messages。
- 调整装备和 wiki 实体选择器，使其使用新的规划器工具提示包装器以及共享的工具提示样式。
- 优化工具提示的滚动关闭行为，引入全局工具提示滚动锁，并将其与现有的 `use-close-on-scroll` hook 集成。
- 为工具提示设置一个非零的默认打开延迟，以减少误触发的悬停激活。
- 保护 wiki 语言区域解析逻辑，对不支持的 locale 回退到 `zh-CN`。

Documentation:
- 修订同步流水线文档，描述客户端 provider、服务端 messages 与 game i18n 目录之间新的 i18n 分层结构。

Tests:
- 新增单元测试，覆盖 game i18n 目录、工具提示滚动锁行为、滚动关闭语义、规划器预览工具提示行为、`useMobileLongPressTooltip` 中桌面悬停锁定行为，并更新现有的 wiki 相关测试，以验证新的基于目录的查找逻辑和工具提示包装器集成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split wiki/game i18n loading into lightweight client messages and full server catalogs while reworking planner tooltips and scroll behavior to avoid large payloads and tooltip flicker.

New Features:
- Introduce separate loadClientMessages and loadMessages helpers to distinguish client UI catalogs from full wikiData used on the server.
- Add a shared PlannerPreviewTooltip component providing unified desktop hover and mobile long-press previews for planner and wiki entity cards.
- Expose a game-i18n-catalogs module for client-side lookup of generated wiki and entity text without inflating NextIntl client messages.

Enhancements:
- Update wiki translation and rich-text hooks to resolve labels via shared game i18n catalogs instead of NextIntl wikiData messages.
- Adjust equipment and wiki entity pickers to use the new planner tooltip wrapper and shared tooltip styling.
- Refine scroll-close behavior for tooltips, introducing a global tooltip scroll lock and integrating it with the existing use-close-on-scroll hook.
- Set a non-zero default tooltip open delay to reduce accidental hover activations.
- Guard wiki locale resolution to fall back to zh-CN for unsupported locales.

Documentation:
- Revise sync pipeline documentation to describe the new i18n layering between client providers, server-side messages, and game i18n catalogs.

Tests:
- Add unit tests covering game i18n catalogs, tooltip scroll lock behavior, close-on-scroll semantics, planner preview tooltip behavior, desktop hover locking in useMobileLongPressTooltip, and update existing wiki-related tests to exercise the new catalog-based lookups and tooltip wrapper integrations.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增统一的规划器预览提示框：桌面支持悬停展示，移动端支持长按预览。
  * 支持多语言内容分层加载（客户端不含长文本数据，按需加载），降低客户端页面负载。
* **体验优化**
  * 滚动时自动关闭预览，减少闪烁与误重开；完善长按/点击交互与选中态表现。
* **文档**
  * 更新前端多语言与长文本使用说明，明确推荐的调用方式与禁用用法。
* **测试**
  * 新增/调整提示框、长按、滚动关闭与多语言相关测试用例与模拟数据。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->