### PR TITLE
feat: 增加网站状态链接，优化面板预览和角色面板配置（尝试修复一些数据错误）

### DIFF
--- a/src/app/[locale]/panel-preview/layout.tsx
+++ b/src/app/[locale]/panel-preview/layout.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from 'next'
 import { getAlternates } from '@/lib/metadata'
 import { loadPlannerCatalogs, loadRouteShellMessages } from '@/i18n/load-messages'
 import { RouteMessages } from '@/components/shared/route-messages'
+import { PLANNER_GRID_TOOLTIP_OPEN_DELAY_MS, TooltipProvider } from '@/components/ui/tooltip'
 import type { WikiLocale } from '@/types/wiki'
-
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params
   const t = await getTranslations({ locale })
@@ -31,5 +31,11 @@ export default async function PanelPreviewLayout({
     ...loadRouteShellMessages(locale as WikiLocale, 'panel-preview'),
     ...loadPlannerCatalogs(locale as WikiLocale, 'panel-preview'),
   }
-  return <RouteMessages messages={messages}>{children}</RouteMessages>
+  return (
+    <RouteMessages messages={messages}>
+      <TooltipProvider delay={PLANNER_GRID_TOOLTIP_OPEN_DELAY_MS}>
+        {children}
+      </TooltipProvider>
+    </RouteMessages>
+  )
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -38,6 +38,7 @@ import {
   ChartNoAxesCombined,
   PanelsTopLeft,
   Languages,
+  ExternalLink,
 } from 'lucide-react'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { FEATURES } from '@/lib/features'
@@ -57,6 +58,7 @@ const NAV_ITEMS = [
 ]
 const TOOL_ITEMS = [
   { href: '/tools/game-i18n', label: 'nav.gameI18nLookup', Icon: Languages },
+  { href: 'https://status.canmoe.com/', label: 'nav.siteStatus', Icon: ExternalLink, external: true },
 ]
 const WIKI_ITEMS = [
   { href: '/wiki/characters', label: 'wiki.categories.characters', Icon: UsersRound },
@@ -296,15 +298,18 @@ export function AppSidebar() {
         <SidebarGroup>
           <SidebarGroupLabel className="group-data-[collapsible=icon]:pointer-events-none">{t('nav.groupTools')}</SidebarGroupLabel>
           <SidebarMenu>
-            {TOOL_ITEMS.map(({ href, label, Icon }) => {
-              const fullHref = `/${locale}${href}`
+            {TOOL_ITEMS.map(({ href, label, Icon, external }) => {
+              const fullHref = external ? href : `/${locale}${href}`
               const labelText = t(label)
               return (
                 <SidebarMenuItem key={href}>
                   <SidebarMenuButton
-                    isActive={pathname.startsWith(fullHref)}
+                    isActive={!external && pathname.startsWith(fullHref)}
                     tooltip={labelText}
-                    render={<NavLink href={fullHref} loadingLabel={labelText} />}
+                    render={external
+                      ? <a href={href} target="_blank" rel="noopener noreferrer" />
+                      : <NavLink href={fullHref} loadingLabel={labelText} />
+                    }
                     onClick={() => {
                       if (isMobile) setOpenMobile(false)
                     }}

--- a/src/components/panel-preview/character-panel-config.test.tsx
+++ b/src/components/panel-preview/character-panel-config.test.tsx
@@ -19,6 +19,8 @@ vi.mock('@/hooks/use-wiki-translations', () => ({
   useWikiTranslations: () => ({
     entityName: (entity: { id: string }) => entity.id,
     text: (...segments: Array<string | number>) => String(segments.at(-1)),
+    equipmentStatLabel: (id: string) => id,
+    enumLabel: (_group: string, id: string) => id,
   }),
 }))
 

--- a/src/components/panel-preview/character-panel-config.tsx
+++ b/src/components/panel-preview/character-panel-config.tsx
@@ -69,10 +69,10 @@ export function CharacterPanelConfig() {
                 {active.map((p) => {
                   const statTexts = p.stats.map((s) => {
                     const label = equipmentStatLabel(s.attributeId) || enumLabel('attributes', s.attributeId)
-                    const val = s.isPercent ? `${(s.value * 100).toFixed(1)}%` : String(s.value)
-                    return `${label}+${val}`
+                    const val = s.isPercent ? `${+(s.value * 100).toFixed(1)}%` : String(s.value)
+                    return `${label} +${val}`
                   })
-                  return <span key={p.id} className="mr-2 inline-block">{text('ui', 'potentialLevel')} {p.level}: {statTexts.join('，')}</span>
+                  return <span key={p.id} className="mr-2 inline-block">{text('ui', 'potentialLevel')} {p.level}: {statTexts.join(', ')}</span>
                 })}
               </p>
             )
@@ -92,9 +92,9 @@ export function CharacterPanelConfig() {
             if (totals.size === 0) return null
             const parts = [...totals.entries()].map(([attrId, val]) => {
               const label = equipmentStatLabel(attrId) || enumLabel('attributes', attrId)
-              return `${label}+${val}`
+              return `${label} +${val}`
             })
-            return <p className="text-[10px] leading-relaxed text-muted-foreground/80">{parts.join('，')}</p>
+            return <p className="text-[10px] leading-relaxed text-muted-foreground/80">{parts.join(', ')}</p>
           })()}
         </div>
       </div>}

--- a/src/components/panel-preview/character-panel-config.tsx
+++ b/src/components/panel-preview/character-panel-config.tsx
@@ -22,7 +22,7 @@ const SKILL_TYPE_KEYS: Record<string, string> = {
 
 export function CharacterPanelConfig() {
   const t = useTranslations('panelPreview')
-  const { entityName, text } = useWikiTranslations()
+  const { entityName, text, equipmentStatLabel, enumLabel } = useWikiTranslations()
   const [pickerOpen, setPickerOpen] = useState(false)
   const config = usePanelPreviewStore((state) => state.config)
   const setCharacter = usePanelPreviewStore((state) => state.setCharacter)
@@ -59,8 +59,44 @@ export function CharacterPanelConfig() {
           return <div key={skill.id} className="grid grid-cols-[minmax(0,1fr)_6rem] items-center gap-3"><div className="min-w-0"><p className="truncate text-sm">{skillName}</p><p className="text-[11px] text-muted-foreground">{typeName}</p></div><NumberField value={config.skillLevels[index] ?? skill.maxLevel} minimum={1} maximum={skill.maxLevel} ariaLabel={`${typeName} ${skillName}`} onValueChange={(value) => { const skillLevels = [...config.skillLevels]; skillLevels[index] = value; updateConfig({ skillLevels }) }} /></div>
         })}
         <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-center gap-3"><Label>{text('ui', 'talent')}</Label><NumberField value={config.talentCount} minimum={0} maximum={data.talents.length} ariaLabel={text('ui', 'talent')} onValueChange={(value) => updateConfig({ talentCount: value })} /></div>
-        <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-center gap-3"><Label>{text('ui', 'potentialLevel')}</Label><NumberField value={config.potentialLevel} minimum={0} maximum={data.potentials.at(-1)?.level ?? 0} ariaLabel={text('ui', 'potentialLevel')} onValueChange={(value) => updateConfig({ potentialLevel: value })} /></div>
-        <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-center gap-3"><Label>{text('ui', 'attributeIncrease')}</Label><NumberField value={config.attributeNodeCount} minimum={0} maximum={data.attributeNodes.length} ariaLabel={text('ui', 'attributeIncrease')} onValueChange={(value) => updateConfig({ attributeNodeCount: value })} /></div>
+        <div className="space-y-1.5">
+          <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-center gap-3"><Label>{text('ui', 'potentialLevel')}</Label><NumberField value={config.potentialLevel} minimum={0} maximum={data.potentials.at(-1)?.level ?? 0} ariaLabel={text('ui', 'potentialLevel')} onValueChange={(value) => updateConfig({ potentialLevel: value })} /></div>
+          {config.potentialLevel > 0 && (() => {
+            const active = data.potentials.filter((p) => p.level <= config.potentialLevel)
+            if (active.length === 0) return null
+            return (
+              <p className="text-[10px] leading-relaxed text-muted-foreground/80">
+                {active.map((p) => {
+                  const statTexts = p.stats.map((s) => {
+                    const label = equipmentStatLabel(s.attributeId) || enumLabel('attributes', s.attributeId)
+                    const val = s.isPercent ? `${(s.value * 100).toFixed(1)}%` : String(s.value)
+                    return `${label}+${val}`
+                  })
+                  return <span key={p.id} className="mr-2 inline-block">{text('ui', 'potentialLevel')} {p.level}: {statTexts.join('，')}</span>
+                })}
+              </p>
+            )
+          })()}
+        </div>
+        <div className="space-y-1.5">
+          <div className="grid grid-cols-[minmax(0,1fr)_6rem] items-center gap-3"><Label>{text('ui', 'attributeIncrease')}</Label><NumberField value={config.attributeNodeCount} minimum={0} maximum={data.attributeNodes.length} ariaLabel={text('ui', 'attributeIncrease')} onValueChange={(value) => updateConfig({ attributeNodeCount: value })} /></div>
+          {config.attributeNodeCount > 0 && (() => {
+            const active = data.attributeNodes.slice(0, config.attributeNodeCount)
+            // Aggregate stats by attributeId
+            const totals = new Map<string, number>()
+            for (const node of active) {
+              for (const stat of node.stats) {
+                totals.set(stat.attributeId, (totals.get(stat.attributeId) ?? 0) + stat.value)
+              }
+            }
+            if (totals.size === 0) return null
+            const parts = [...totals.entries()].map(([attrId, val]) => {
+              const label = equipmentStatLabel(attrId) || enumLabel('attributes', attrId)
+              return `${label}+${val}`
+            })
+            return <p className="text-[10px] leading-relaxed text-muted-foreground/80">{parts.join('，')}</p>
+          })()}
+        </div>
       </div>}
     </section>
   )

--- a/src/components/panel-preview/panel-stats-summary.tsx
+++ b/src/components/panel-preview/panel-stats-summary.tsx
@@ -27,8 +27,11 @@ type CoreStatKey = keyof typeof CORE_STAT_ATTR_ID
 const CONTRIBUTION_TARGET_LABEL_ID: Record<string, string> = {
   hp: '1',
   attack: '2',
-  physicalDamageReduction: '4',
-  fireDamageReduction: '5',
+  physicalDamageReduction: '80',
+  fireDamageReduction: '84',
+  pulseDamageReduction: '83',
+  crystDamageReduction: '82',
+  naturalDamageReduction: '81',
   healingReceived: '30',
   /** Defense-derived damage reduction; closest game composite label. */
   defenseDamageReduction: 'AllDamageTakenScalar',

--- a/src/lib/planner/progression.ts
+++ b/src/lib/planner/progression.ts
@@ -355,13 +355,86 @@ function applyEquipmentSetValues(
   }
 }
 
+const SK_WPN_PERMANENT_PATTERNS: Array<{ pattern: RegExp; handler: 'core' | 'mainAttr' | 'subAttr' | 'modifier'; attributeId?: string }> = [
+  { pattern: /^攻击力/, handler: 'core', attributeId: CORE_ATTRIBUTE_IDS.attack },
+  { pattern: /^主能力/, handler: 'mainAttr' },
+  { pattern: /^副能力/, handler: 'subAttr' },
+  { pattern: /^最大生命值/, handler: 'core', attributeId: CORE_ATTRIBUTE_IDS.hp },
+  { pattern: /^防御力/, handler: 'core', attributeId: CORE_ATTRIBUTE_IDS.defense },
+  { pattern: /^物理伤害/, handler: 'modifier', attributeId: '50' },
+  { pattern: /^法术伤害/, handler: 'modifier', attributeId: 'SpellDamageIncrease' },
+  { pattern: /^灼热伤害/, handler: 'modifier', attributeId: 'FireDamageIncrease' },
+  { pattern: /^电磁伤害/, handler: 'modifier', attributeId: 'PulseDamageIncrease' },
+  { pattern: /^寒冷伤害/, handler: 'modifier', attributeId: 'CrystDamageIncrease' },
+  { pattern: /^自然伤害/, handler: 'modifier', attributeId: 'NaturalDamageIncrease' },
+  { pattern: /^源石技艺强度/, handler: 'modifier', attributeId: '87' },
+  { pattern: /^暴击率/, handler: 'modifier', attributeId: '9' },
+  { pattern: /^治疗效率/, handler: 'modifier', attributeId: '29' },
+  { pattern: /^所有技能伤害/, handler: 'modifier', attributeId: 'AllSkillDamageIncrease' },
+  { pattern: /^战技伤害/, handler: 'modifier', attributeId: 'NormalSkillDamageIncrease' },
+  { pattern: /^终结技伤害/, handler: 'modifier', attributeId: 'UltimateSkillDamageIncrease' },
+  { pattern: /^连携技伤害/, handler: 'modifier', attributeId: 'ComboSkillDamageIncrease' },
+]
+
+/** Extract the first sentence (before \n or first 。) from a weapon skill description. */
+function firstSentence(description: string): string {
+  const newlineIdx = description.indexOf('\n')
+  const periodIdx = description.indexOf('。')
+  const end = Math.min(
+    newlineIdx >= 0 ? newlineIdx : Infinity,
+    periodIdx >= 0 ? periodIdx + 1 : Infinity,
+  )
+  return end < Infinity ? description.slice(0, end) : description
+}
+
+/**
+ * Parse and apply a sk_wpn_* (third weapon skill) permanent bonus.
+ * Only the first sentence is considered; if it matches a known stat
+ * pattern it is treated as unconditional, otherwise the skill is skipped.
+ */
+function applySkWpnSkill(
+  stats: PanelStats,
+  percentages: Partial<Record<CorePanelStatKey, number>>,
+  modifiers: Map<string, PanelStatModifier>,
+  character: PlannerCharacter,
+  description: string,
+): void {
+  const sentence = firstSentence(description)
+  if (!sentence) return
+  const isPercent = sentence.includes('%')
+  const value = Math.abs(parseFirstNumber(sentence))
+  if (value === 0) return
+
+  for (const { pattern, handler, attributeId } of SK_WPN_PERMANENT_PATTERNS) {
+    if (!pattern.test(sentence)) continue
+    switch (handler) {
+      case 'core':
+        if (attributeId) applyCoreValue(stats, percentages, attributeId, value, isPercent)
+        return
+      case 'mainAttr':
+        applyCoreValue(stats, percentages, character.mainAttributeId, value, isPercent)
+        addModifier(modifiers, 'Main', value, isPercent)
+        return
+      case 'subAttr':
+        applyCoreValue(stats, percentages, character.subAttributeId, value, isPercent)
+        addModifier(modifiers, 'Sub', value, isPercent)
+        return
+      case 'modifier':
+        if (attributeId) addModifier(modifiers, attributeId, value, isPercent)
+        return
+    }
+  }
+  // Sentence didn't match any known permanent pattern → likely conditional (e.g.
+  // "装备者的战技命中敌人时…").  Skip silently.
+}
+
 function applyWeaponSkill(
   stats: PanelStats,
   percentages: Partial<Record<CorePanelStatKey, number>>,
   modifiers: Map<string, PanelStatModifier>,
   character: PlannerCharacter,
   skillId: string,
-  description: string
+  description: string,
 ): void {
   const value = Math.abs(parseFirstNumber(description))
   if (skillId.startsWith('wpn_attr_str_')) stats.strength += value
@@ -374,7 +447,7 @@ function applyWeaponSkill(
   }
   else if (skillId.startsWith('wpn_sp_attr_atk_')) applyCoreValue(stats, percentages, CORE_ATTRIBUTE_IDS.attack, value, true)
   else if (skillId.startsWith('wpn_sp_attr_hp_')) applyCoreValue(stats, percentages, CORE_ATTRIBUTE_IDS.hp, value, true)
-  else if (skillId.startsWith('sk_wpn_') && !description.includes('%')) stats.attack += value
+  else if (skillId.startsWith('sk_wpn_')) applySkWpnSkill(stats, percentages, modifiers, character, description)
   else {
     const modifierId = WEAPON_MODIFIER_IDS.find(([prefix]) => skillId.startsWith(prefix))?.[1]
     if (modifierId) addModifier(modifiers, modifierId, value, description.includes('%'))
@@ -402,11 +475,19 @@ function addDerivedAttributes(gameData: PlannerGameData, stats: PanelStats, cont
   if (subAttackIncrease > 0) contributions.push({ source: attributeSource(character.subAttributeId), target: 'attack', value: subAttackIncrease * 100, isPercent: true })
 
   const physicalResistance = stats.agility * derived.efficiencyOfAGI * 100
-  const fireResistance = stats.intellect * derived.efficiencyOfWISD * 100
-  const healingIncrease = stats.will * derived.recoverEfficiencyOfWILL * 100
   if (physicalResistance > 0) contributions.push({ source: 'agility', target: 'physicalDamageReduction', value: physicalResistance, isPercent: true })
-  if (fireResistance > 0) contributions.push({ source: 'intellect', target: 'fireDamageReduction', value: fireResistance, isPercent: true })
+
+  // Intellect (WISD) provides spell resistance, which reduces elemental spell damage.
+  const spellResistance = stats.intellect * derived.efficiencyOfWISD * 100
+  if (spellResistance > 0) {
+    for (const target of ['fireDamageReduction', 'pulseDamageReduction', 'crystDamageReduction', 'naturalDamageReduction'] as const) {
+      contributions.push({ source: 'intellect', target, value: spellResistance, isPercent: true })
+    }
+  }
+
+  const healingIncrease = stats.will * derived.recoverEfficiencyOfWILL * 100
   if (healingIncrease > 0) contributions.push({ source: 'will', target: 'healingReceived', value: healingIncrease, isPercent: true })
+
   const damageReduction = 1 - 1 / (1 + derived.efficiencyOfDEF * stats.defense)
   if (damageReduction > 0) contributions.push({ source: 'defense', target: 'defenseDamageReduction', value: damageReduction * 100, isPercent: true })
 }
@@ -461,7 +542,7 @@ export function calculatePanelStats(config: PanelPreviewConfig): PanelStats {
     const weapon = gameData.weapons[config.weaponId]
     const weaponLevel = weapon?.levels.find((entry) => entry.level === config.weaponLevel) ?? weapon?.levels.at(-1)
     stats.attack += weaponLevel?.baseAttack ?? 0
-    weapon?.skills.slice(0, 2).forEach((skill, index) => {
+    weapon?.skills.forEach((skill, index) => {
       const selectedLevel = clamp(config.weaponSkillLevels[index] ?? 1, 1, skill.levels.at(-1)?.level ?? 1)
       const description = skill.levels.find((entry) => entry.level === selectedLevel)?.description ?? ''
       applyWeaponSkill(stats, percentages, modifiers, character, skill.id, description)

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -34,6 +34,7 @@
     "growthPlanner": "Growth Planner",
     "panelPreview": "Stats Preview",
     "gameI18nLookup": "Game text lookup",
+    "siteStatus": "Site Status",
     "groupModules": "Modules",
     "groupWiki": "Wiki",
     "groupTools": "More Tools"

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -34,6 +34,7 @@
     "growthPlanner": "育成計画",
     "panelPreview": "ステータスプレビュー",
     "gameI18nLookup": "ゲームテキスト検索",
+    "siteStatus": "サイトステータス",
     "groupModules": "モジュール",
     "groupWiki": "図鑑",
     "groupTools": "その他ツール"

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -34,6 +34,7 @@
     "growthPlanner": "养成规划",
     "panelPreview": "面板预览",
     "gameI18nLookup": "游戏文案查询",
+    "siteStatus": "网站状态",
     "groupModules": "模块",
     "groupWiki": "图鉴",
     "groupTools": "更多工具"

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -34,6 +34,7 @@
     "growthPlanner": "養成規劃",
     "panelPreview": "面板預覽",
     "gameI18nLookup": "遊戲文案查詢",
+    "siteStatus": "網站狀態",
     "groupModules": "模組",
     "groupWiki": "圖鑑",
     "groupTools": "更多工具"

--- a/src/types/planner.ts
+++ b/src/types/planner.ts
@@ -224,8 +224,7 @@ export interface PanelStatModifier {
   value: number
   isPercent: boolean
 }
-
-export type PanelAttributeContributionTarget = 'hp' | 'attack' | 'physicalDamageReduction' | 'fireDamageReduction' | 'healingReceived' | 'defenseDamageReduction'
+export type PanelAttributeContributionTarget = 'hp' | 'attack' | 'physicalDamageReduction' | 'fireDamageReduction' | 'pulseDamageReduction' | 'crystDamageReduction' | 'naturalDamageReduction' | 'healingReceived' | 'defenseDamageReduction'
 
 export interface PanelAttributeContribution {
   source: 'strength' | 'agility' | 'intellect' | 'will' | 'defense'


### PR DESCRIPTION
## Summary by Sourcery

改进面板预览的计算和界面，扩展武器技能处理逻辑，并在工具侧边栏中添加站点状态链接。

新功能：
- 新增支持：根据第三武器技能的描述解析并应用其永久加成。
- 在侧边栏导航的工具部分添加指向站点状态的外部链接。
- 在角色面板配置中内联显示已汇总的潜能与属性节点的属性加成。

改进：
- 在面板属性贡献中，将由智力派生的法术抗性视为可减少多种元素伤害类型，并更新相应的贡献标签。
- 计算面板属性时使用所有武器技能，而不再仅限于前两个技能。
- 将面板预览路由包裹在 tooltip 提供器中，以启用一致的工具提示表现。
- 扩展规划器的属性贡献目标，以涵盖更多元素伤害减免属性。

测试：
- 更新角色面板配置测试，以适配用于内联属性汇总的新翻译辅助函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve panel preview calculations and UI, extend weapon skill handling, and add a site status link to the tools sidebar.

New Features:
- Add support for parsing and applying permanent bonuses from third weapon skills based on their descriptions.
- Add a site status external link to the tools section of the sidebar navigation.
- Show aggregated potential and attribute node stat bonuses inline in the character panel configuration.

Enhancements:
- Treat intellect-derived spell resistance as reducing multiple elemental damage types in panel stat contributions and update corresponding contribution labels.
- Calculate panel stats using all weapon skills instead of limiting to the first two.
- Wrap the panel preview route in a tooltip provider to enable consistent tooltips.
- Extend planner contribution targets to cover additional elemental damage reduction stats.

Tests:
- Update character panel configuration tests to account for new translation helpers used in the inline stat summaries.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 工具侧栏新增“网站状态”外链入口，新标签页打开。
- **改进**
  - 角色配置面板根据潜能等级与属性节点数量展示加成明细与汇总。
  - 伤害减免与武器技能效果计算更全面，映射与统计更准确。
  - 优化工具提示打开延迟。
- **语言**
  - 补充“网站状态”多语言文案。
- **测试**
  - 更新相关测试的翻译模拟。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->