### PR TITLE
feat: 将筛选功能复用

### DIFF
--- a/src/app/[locale]/wiki/equipment/page.tsx
+++ b/src/app/[locale]/wiki/equipment/page.tsx
@@ -44,6 +44,10 @@ export default async function WikiEquipmentPage({ params }: { params: Promise<{ 
         filters={[
           { field: 'rarity', labelKey: 'wiki.filter.rarity' },
           { field: 'partTypeId', labelKey: 'wiki.filter.partType', enumGroup: 'equipmentParts' },
+          // 精锻属性筛选: 仅 5★ 装备有数据, 标签复用 refinement 命名空间 (equipStats 前缀解析属性名)。
+          { field: 'sub1', labelKey: 'refinement.subAttr1', labelPrefix: 'equipStats' },
+          { field: 'sub2', labelKey: 'refinement.subAttr2', labelPrefix: 'equipStats' },
+          { field: 'special', labelKey: 'refinement.specialEffect', labelPrefix: 'equipStats' },
         ]}
       />
     </div>

--- a/src/app/[locale]/wiki/layout.tsx
+++ b/src/app/[locale]/wiki/layout.tsx
@@ -1,6 +1,6 @@
 import { getTranslations } from 'next-intl/server'
 import type { Metadata } from 'next'
-import { loadRouteShellMessages } from '@/i18n/load-messages'
+import { loadPlannerCatalogs, loadRouteShellMessages } from '@/i18n/load-messages'
 import { RouteMessages } from '@/components/shared/route-messages'
 import type { WikiLocale } from '@/types/wiki'
 
@@ -37,6 +37,10 @@ export default async function WikiLayout({
 }) {
   const { locale } = await params
   // wiki 客户端孤岛 (grid/detail islands) + 装备型号后缀 refinement.modelType*
-  const messages = loadRouteShellMessages(locale as WikiLocale, 'wiki')
+  // + equipStats (装备页精锻属性筛选 chips 的属性名, 如 equipStats.41 → 智识)。
+  const messages = {
+    ...loadRouteShellMessages(locale as WikiLocale, 'wiki'),
+    ...loadPlannerCatalogs(locale as WikiLocale, 'wiki'),
+  }
   return <RouteMessages messages={messages}>{children}</RouteMessages>
 }

--- a/src/components/essence/weapon-grid.tsx
+++ b/src/components/essence/weapon-grid.tsx
@@ -2,12 +2,9 @@
 
 import { memo, useMemo, useCallback, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
-import { ChevronDown } from 'lucide-react'
-import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
-
-import { FilterChip } from '@/components/shared/filter-chip'
+import { FilterGroup } from '@/components/shared/filter-group'
+import { FilterPanel } from '@/components/shared/filter-panel'
 import { WeaponCard } from './weapon-card'
 import { SelectedWeaponsStrip } from './selected-weapons-strip'
 import { weapons as staticWeapons } from '@/data/weapons'
@@ -246,54 +243,27 @@ export const WeaponGrid = memo(function WeaponGrid({ onViewAll }: WeaponGridProp
         onViewAll={onViewAll}
       />
 
-      {/* Attribute filter — collapsible */}
-      <div>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={toggleFilterCollapsed}
-          aria-expanded={!filterCollapsed}
-          className="flex min-h-10 w-full items-center gap-2 px-3 text-sm text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ChevronDown className={cn('size-4 transition-transform', filterCollapsed ? '-rotate-90' : 'rotate-0')} />
-          <span className="flex-1 text-left">{t('essence.attrFilterTitle')}</span>
-        </Button>
-        <div
-          id="weapon-attr-filter"
-          className={cn(
-            'grid transition-all duration-200 ease-out',
-            filterCollapsed ? 'grid-rows-[0fr] opacity-0' : 'grid-rows-[1fr] opacity-100',
-          )}
-        >
-          <div className="overflow-hidden">
-            <div className="mt-1.5 flex flex-col gap-2">
-              {ATTR_KEYS.map((key) => {
-                const values = attrValues[key]
-                const valid = validOptions[key]
-                const selected = filters[key]
-                const isSpecialAbility = key === 'specialAbility'
-                return (
-                  <div key={key} className="flex flex-col gap-1">
-                    <span className="text-[10px] text-muted-foreground">{t(ATTR_LABEL_KEYS[key])}</span>
-                    <div className={isSpecialAbility ? 'grid grid-cols-[repeat(auto-fill,minmax(3.5rem,1fr))] gap-1' : 'grid grid-cols-[repeat(auto-fill,minmax(5.5rem,1fr))] gap-1'}>
-                      {values.map((value) => (
-                        <FilterChip
-                          key={value}
-                          value={value}
-                          label={key === 'weaponType' ? weaponTypeLabel(value, t) : t(`weaponStats.${value}`)}
-                          isValid={valid.has(value)}
-                          isSelected={selected.has(value)}
-                          onToggle={() => toggleFilter(key, value)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-        </div>
-      </div>
+      {/* Attribute filter — collapsible (shared FilterPanel/FilterGroup) */}
+      <FilterPanel
+        title={t('essence.attrFilterTitle')}
+        collapsed={filterCollapsed}
+        onToggle={toggleFilterCollapsed}
+      >
+        {ATTR_KEYS.map((key) => (
+          <FilterGroup
+            key={key}
+            label={t(ATTR_LABEL_KEYS[key])}
+            chipColumnClass={key === 'specialAbility' ? 'grid-cols-[repeat(auto-fill,minmax(3.5rem,1fr))]' : undefined}
+            chips={attrValues[key].map((value) => ({
+              key: value,
+              label: key === 'weaponType' ? weaponTypeLabel(value, t) : t(`weaponStats.${value}`),
+              valid: validOptions[key].has(value),
+              selected: filters[key].has(value),
+              onToggle: () => toggleFilter(key, value),
+            }))}
+          />
+        ))}
+      </FilterPanel>
 
       <div className="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-2">
         {filteredWeapons.map((weapon) => (

--- a/src/components/panel-preview/equipment-suit-picker.test.tsx
+++ b/src/components/panel-preview/equipment-suit-picker.test.tsx
@@ -131,3 +131,15 @@ it('filters equipment by refinement sub-attributes', () => {
   fireEvent.click(screen.getByRole('button', { name: 'refinement.clearFilters' }))
   expect(screen.queryByText('1', { selector: '.font-geist-mono' })).toBeNull()
 })
+
+it('clears refinement filters when partTypeId changes', () => {
+  const { rerender } = render(<EquipmentSuitPicker partTypeId="0" selectedId={null} onSelect={() => undefined} />)
+  fireEvent.click(screen.getByRole('button', { name: 'refinement.attributeFilters' }))
+  fireEvent.click(screen.getByRole('button', { name: 'equipStats.41' }))
+  expect(screen.getByText('1', { selector: '.font-geist-mono' })).toBeTruthy()
+
+  // 切换部位: 旧部位的筛选值必须清空, 避免污染新部位列表。
+  rerender(<EquipmentSuitPicker partTypeId="1" selectedId={null} onSelect={() => undefined} />)
+  expect(screen.queryByText('1', { selector: '.font-geist-mono' })).toBeNull()
+  expect(screen.queryByRole('button', { name: 'refinement.clearFilters' })).toBeNull()
+})

--- a/src/components/panel-preview/equipment-suit-picker.test.tsx
+++ b/src/components/panel-preview/equipment-suit-picker.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { cloneElement } from 'react'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { EquipmentSuitPicker } from './equipment-suit-picker'
@@ -44,6 +45,13 @@ vi.mock('@/components/shared/rarity-frame', () => ({
   RarityFrame: ({ title }: { title: string }) => <span>{title}</span>,
 }))
 
+vi.mock('@/lib/equip-substats', () => ({
+  equipSubAttrKey: (id: string, slot: string) => {
+    if (id === 'equipment-test') return slot === 'sub1' ? '41' : slot === 'sub2' ? '39' : 'AllSkillDamageIncrease'
+    return ''
+  },
+}))
+
 vi.mock('@/components/shared/planner-wiki-preview', () => ({
   PlannerWikiPreview: ({ rows }: { rows: Array<{ label: string }> }) => <div>{rows.map((row) => <span key={row.label}>{row.label}</span>)}</div>,
 }))
@@ -66,7 +74,8 @@ vi.mock('@/hooks/use-mobile-long-press-tooltip', () => ({
 
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipTrigger: ({ render: trigger }: { render: React.ReactNode }) => <>{trigger}</>,
+  // render 是触发器元素 (如 Button), children 是其内容: 组合后 accessible name 才完整。
+  TooltipTrigger: ({ render, children }: { render: React.ReactElement; children: React.ReactNode }) => cloneElement(render, undefined, children),
   TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   TOOLTIP_OPEN_DELAY_MS: 0,
 }))
@@ -91,4 +100,34 @@ it('uses localized equipment stat labels in selection tooltips', () => {
 
   expect(screen.getByText('所有技能伤害加成')).toBeTruthy()
   expect(screen.queryByText('AllSkillDamageIncrease')).toBeNull()
+})
+
+it('filters equipment by refinement sub-attributes', () => {
+  render(<EquipmentSuitPicker partTypeId="0" selectedId={null} onSelect={() => undefined} />)
+
+  // 折叠状态下只有切换按钮; 展开后出现三组属性 chip。
+  const toggle = screen.getByRole('button', { name: 'refinement.attributeFilters' })
+  expect(toggle.getAttribute('aria-expanded')).toBe('false')
+  fireEvent.click(toggle)
+  expect(toggle.getAttribute('aria-expanded')).toBe('true')
+
+  expect(screen.getByText('refinement.subAttr1')).toBeTruthy()
+  expect(screen.getByText('refinement.subAttr2')).toBeTruthy()
+  expect(screen.getByText('refinement.specialEffect')).toBeTruthy()
+
+  // chip 标签走 equipStats 命名空间 (mock 返回 key 本身)。
+  const chip = screen.getByRole('button', { name: 'equipStats.41' })
+  fireEvent.click(chip)
+  // 激活计数 + 清除按钮出现, 装备列表保留。
+  expect(screen.getByText('1', { selector: '.font-geist-mono' })).toBeTruthy()
+  expect(screen.getByRole('button', { name: 'refinement.clearFilters' })).toBeTruthy()
+  expect(screen.getByRole('button', { name: /独立装备/ })).toBeTruthy()
+
+  // 选中不匹配的属性 (sub2 = 39, 而装备 sub2 正是 39, 装备仍保留)。
+  fireEvent.click(screen.getByRole('button', { name: 'equipStats.39' }))
+  expect(screen.getByRole('button', { name: /独立装备/ })).toBeTruthy()
+
+  // 清除筛选: 计数消失。
+  fireEvent.click(screen.getByRole('button', { name: 'refinement.clearFilters' }))
+  expect(screen.queryByText('1', { selector: '.font-geist-mono' })).toBeNull()
 })

--- a/src/components/panel-preview/equipment-suit-picker.tsx
+++ b/src/components/panel-preview/equipment-suit-picker.tsx
@@ -44,17 +44,26 @@ export function EquipmentSuitPicker({ partTypeId, selectedId, onSelect }: Equipm
   const [filterSub2, setFilterSub2] = useState<string[]>([])
   const [filterSpecial, setFilterSpecial] = useState<string[]>([])
 
-  const filterState: Record<EquipSubSlot, string[]> = { sub1: filterSub1, sub2: filterSub2, special: filterSpecial }
-  const setFilterState: Record<EquipSubSlot, (value: string[]) => void> = {
-    sub1: setFilterSub1,
-    sub2: setFilterSub2,
-    special: setFilterSpecial,
+  // partTypeId 变化 (切换装备部位) 时清除筛选: 旧部位的属性值不匹配新部位的选项, 保留会筛空列表。
+  // 用 render 阶段修正 (derive state from props), 避免 effect 内同步 setState 的级联渲染。
+  const [prevPartTypeId, setPrevPartTypeId] = useState(partTypeId)
+  if (prevPartTypeId !== partTypeId) {
+    setPrevPartTypeId(partTypeId)
+    setFilterSub1([])
+    setFilterSub2([])
+    setFilterSpecial([])
   }
+
+  const filterState = useMemo(
+    () => ({ sub1: filterSub1, sub2: filterSub2, special: filterSpecial }),
+    [filterSub1, filterSub2, filterSpecial],
+  )
   const activeFilterCount = filterSub1.length + filterSub2.length + filterSpecial.length
 
   const toggleFilter = (slot: EquipSubSlot, value: string) => {
     const current = filterState[slot]
-    setFilterState[slot](current.includes(value) ? current.filter((v) => v !== value) : [...current, value])
+    const setter = slot === 'sub1' ? setFilterSub1 : slot === 'sub2' ? setFilterSub2 : setFilterSpecial
+    setter(current.includes(value) ? current.filter((v) => v !== value) : [...current, value])
   }
   const clearFilters = () => {
     setFilterSub1([])
@@ -82,9 +91,9 @@ export function EquipmentSuitPicker({ partTypeId, selectedId, onSelect }: Equipm
       if (equipment.partTypeId !== partTypeId) continue
       if (term && !entityName(equipment).toLocaleLowerCase(locale).includes(term) && !equipment.id.toLocaleLowerCase(locale).includes(term)) continue
       // 精锻属性筛选: 选中集合为空或该槽位命中。
-      if (filterSub1.length > 0 && !filterSub1.includes(equipSubAttrKey(equipment.id, 'sub1'))) continue
-      if (filterSub2.length > 0 && !filterSub2.includes(equipSubAttrKey(equipment.id, 'sub2'))) continue
-      if (filterSpecial.length > 0 && !filterSpecial.includes(equipSubAttrKey(equipment.id, 'special'))) continue
+      for (const { slot } of FILTER_GROUPS) {
+        if (filterState[slot].length > 0 && !filterState[slot].includes(equipSubAttrKey(equipment.id, slot))) continue
+      }
       const key = equipment.suitId ?? '__no-set__'
       grouped.set(key, [...(grouped.get(key) ?? []), equipment])
     }
@@ -95,7 +104,7 @@ export function EquipmentSuitPicker({ partTypeId, selectedId, onSelect }: Equipm
         equipment: equipment.sort((left, right) => right.rarity - left.rarity || entityName(left).localeCompare(entityName(right))),
       }))
       .sort((left, right) => left.key === '__no-set__' ? -1 : right.key === '__no-set__' ? 1 : (right.equipment[0]?.rarity ?? 0) - (left.equipment[0]?.rarity ?? 0) || left.label.localeCompare(right.label))
-  }, [entityName, filterSpecial, filterSub1, filterSub2, locale, partTypeId, search, suitName, t])
+  }, [entityName, filterState, locale, partTypeId, search, suitName, t])
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">

--- a/src/components/panel-preview/equipment-suit-picker.tsx
+++ b/src/components/panel-preview/equipment-suit-picker.tsx
@@ -6,16 +6,25 @@ import { useLocale, useTranslations } from 'next-intl'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { FilterGroup } from '@/components/shared/filter-group'
+import { FilterPanel } from '@/components/shared/filter-panel'
 import { PlannerPreviewTooltip } from '@/components/shared/planner-preview-tooltip'
 import { PlannerWikiPreview } from '@/components/shared/planner-wiki-preview'
 import { RarityFrame } from '@/components/shared/rarity-frame'
 import { wikiEquipment } from '@/generated/data/wiki/equipment'
 import { wikiEquipmentPlannerPreviews } from '@/generated/data/wiki/planner-previews'
 import { useWikiTranslations } from '@/hooks/use-wiki-translations'
+import { equipSubAttrKey, type EquipSubSlot } from '@/lib/equip-substats'
 import { PLANNER_SELECTED_BADGE_CLASS, PLANNER_SELECTED_RING_CLASS } from '@/lib/planner-selection-styles'
 import { cn } from '@/lib/utils'
 import type { WikiEquipmentSummary, WikiLocale } from '@/types/wiki'
 
+/** 精锻属性筛选组: 与精锻规划一致, 标签复用 refinement 命名空间。 */
+const FILTER_GROUPS: Array<{ slot: EquipSubSlot; labelKey: string }> = [
+  { slot: 'sub1', labelKey: 'refinement.subAttr1' },
+  { slot: 'sub2', labelKey: 'refinement.subAttr2' },
+  { slot: 'special', labelKey: 'refinement.specialEffect' },
+]
 export interface EquipmentSuitPickerProps {
   partTypeId: string
   selectedId: string | null
@@ -30,12 +39,52 @@ export function EquipmentSuitPicker({ partTypeId, selectedId, onSelect }: Equipm
   const { entityName, suitName, equipmentStatLabel } = useWikiTranslations()
   const [search, setSearch] = useState('')
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [filterCollapsed, setFilterCollapsed] = useState(true)
+  const [filterSub1, setFilterSub1] = useState<string[]>([])
+  const [filterSub2, setFilterSub2] = useState<string[]>([])
+  const [filterSpecial, setFilterSpecial] = useState<string[]>([])
+
+  const filterState: Record<EquipSubSlot, string[]> = { sub1: filterSub1, sub2: filterSub2, special: filterSpecial }
+  const setFilterState: Record<EquipSubSlot, (value: string[]) => void> = {
+    sub1: setFilterSub1,
+    sub2: setFilterSub2,
+    special: setFilterSpecial,
+  }
+  const activeFilterCount = filterSub1.length + filterSub2.length + filterSpecial.length
+
+  const toggleFilter = (slot: EquipSubSlot, value: string) => {
+    const current = filterState[slot]
+    setFilterState[slot](current.includes(value) ? current.filter((v) => v !== value) : [...current, value])
+  }
+  const clearFilters = () => {
+    setFilterSub1([])
+    setFilterSub2([])
+    setFilterSpecial([])
+  }
+
+  /** 该部位实际存在的精锻属性 (5★ 装备才有数据), 不存在的属性不显示。 */
+  const filterOptions = useMemo(() => {
+    const options: Record<EquipSubSlot, string[]> = { sub1: [], sub2: [], special: [] }
+    for (const equipment of wikiEquipment) {
+      if (equipment.partTypeId !== partTypeId) continue
+      for (const slot of FILTER_GROUPS.map((group) => group.slot)) {
+        const key = equipSubAttrKey(equipment.id, slot)
+        if (key && !options[slot].includes(key)) options[slot].push(key)
+      }
+    }
+    return options
+  }, [partTypeId])
+
   const groups = useMemo(() => {
     const term = search.trim().toLocaleLowerCase(locale)
     const grouped = new Map<string, WikiEquipmentSummary[]>()
     for (const equipment of wikiEquipment) {
       if (equipment.partTypeId !== partTypeId) continue
       if (term && !entityName(equipment).toLocaleLowerCase(locale).includes(term) && !equipment.id.toLocaleLowerCase(locale).includes(term)) continue
+      // 精锻属性筛选: 选中集合为空或该槽位命中。
+      if (filterSub1.length > 0 && !filterSub1.includes(equipSubAttrKey(equipment.id, 'sub1'))) continue
+      if (filterSub2.length > 0 && !filterSub2.includes(equipSubAttrKey(equipment.id, 'sub2'))) continue
+      if (filterSpecial.length > 0 && !filterSpecial.includes(equipSubAttrKey(equipment.id, 'special'))) continue
       const key = equipment.suitId ?? '__no-set__'
       grouped.set(key, [...(grouped.get(key) ?? []), equipment])
     }
@@ -46,7 +95,7 @@ export function EquipmentSuitPicker({ partTypeId, selectedId, onSelect }: Equipm
         equipment: equipment.sort((left, right) => right.rarity - left.rarity || entityName(left).localeCompare(entityName(right))),
       }))
       .sort((left, right) => left.key === '__no-set__' ? -1 : right.key === '__no-set__' ? 1 : (right.equipment[0]?.rarity ?? 0) - (left.equipment[0]?.rarity ?? 0) || left.label.localeCompare(right.label))
-  }, [entityName, locale, partTypeId, search, suitName, t])
+  }, [entityName, filterSpecial, filterSub1, filterSub2, locale, partTypeId, search, suitName, t])
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
@@ -59,6 +108,31 @@ export function EquipmentSuitPicker({ partTypeId, selectedId, onSelect }: Equipm
           placeholder={rootT('wiki.searchPlaceholder')}
           aria-label={rootT('wiki.searchPlaceholder')}
         />
+      </div>
+      {/* 精锻属性筛选: 共享 FilterPanel/FilterGroup, 与精锻规划交互一致。 */}
+      <div className="shrink-0">
+        <FilterPanel
+          title={rootT('refinement.attributeFilters')}
+          collapsed={filterCollapsed}
+          onToggle={() => setFilterCollapsed((value) => !value)}
+          activeCount={activeFilterCount}
+          onClear={clearFilters}
+          clearLabel={rootT('refinement.clearFilters')}
+        >
+          {FILTER_GROUPS.map(({ slot, labelKey }) => (
+            <FilterGroup
+              key={slot}
+              label={rootT(labelKey)}
+              chips={filterOptions[slot].map((value) => ({
+                key: value,
+                label: rootT(`equipStats.${value}`),
+                valid: true,
+                selected: filterState[slot].includes(value),
+                onToggle: () => toggleFilter(slot, value),
+              }))}
+            />
+          ))}
+        </FilterPanel>
       </div>
       <div className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
         {groups.map((group) => {

--- a/src/components/refinement/equip-list.tsx
+++ b/src/components/refinement/equip-list.tsx
@@ -2,27 +2,24 @@
 
 import { memo, useMemo } from 'react'
 import { useTranslations } from 'next-intl'
-import { ChevronDown } from 'lucide-react'
-import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
-import { FilterChip } from '@/components/shared/filter-chip'
 import { EquipSetGroup } from './equip-set-group'
 import { useRefinementStore, useGroupedSets } from '@/stores/useRefinementStore'
+import { FilterGroup } from '@/components/shared/filter-group'
+import { FilterPanel } from '@/components/shared/filter-panel'
 import {
   sub1StatOptions,
   sub2StatOptions,
   specialStatOptions,
 } from '@/data/equips'
 
-type FilterGroup = 'sub1' | 'sub2' | 'special'
+type FilterSlot = 'sub1' | 'sub2' | 'special'
 
-const REFINEMENT_FILTER_GROUPS: { filterKey: FilterGroup; labelKey: string; options: string[] }[] = [
+const REFINEMENT_FILTER_GROUPS: { filterKey: FilterSlot; labelKey: string; options: string[] }[] = [
   { filterKey: 'sub1', labelKey: 'refinement.subAttr1', options: sub1StatOptions },
   { filterKey: 'sub2', labelKey: 'refinement.subAttr2', options: sub2StatOptions },
   { filterKey: 'special', labelKey: 'refinement.specialEffect', options: specialStatOptions },
 ]
-
 export const EquipList = memo(function EquipList() {
   const t = useTranslations()
   const searchQuery = useRefinementStore((s) => s.searchQuery)
@@ -41,8 +38,7 @@ export const EquipList = memo(function EquipList() {
     [filterSub1, filterSub2, filterSpecial],
   )
 
-  const hasActiveFilters =
-    filterSub1.length > 0 || filterSub2.length > 0 || filterSpecial.length > 0
+  const activeFilterCount = filterSub1.length + filterSub2.length + filterSpecial.length
 
   return (
     <div className="flex flex-col gap-3">
@@ -54,71 +50,30 @@ export const EquipList = memo(function EquipList() {
         className="text-sm"
       />
 
-      {/* Attribute filter — collapsible */}
-      <div>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={toggleFilterCollapsed}
-          aria-expanded={!filterCollapsed}
-          className="flex min-h-10 w-full items-center gap-2 px-3 text-sm text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ChevronDown className={cn('size-4 transition-transform', filterCollapsed ? '-rotate-90' : 'rotate-0')} />
-          <span className="flex-1 text-left">{t('refinement.attributeFilters')}</span>
-          {hasActiveFilters && <span className="font-geist-mono text-xs">{filterSub1.length + filterSub2.length + filterSpecial.length}</span>}
-        </Button>
-        {hasActiveFilters && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            onClick={clearFilters}
-            className="text-[10px] text-muted-foreground hover:text-foreground h-auto px-1 -mt-0.5"
-          >
-            {t('refinement.clearFilters')}
-          </Button>
-        )}
-        <div
-          className={cn(
-            'grid transition-all duration-200 ease-out',
-            filterCollapsed
-              ? 'grid-rows-[0fr] opacity-0'
-              : 'grid-rows-[1fr] opacity-100',
-          )}
-        >
-          <div className="overflow-hidden">
-            <div className="flex flex-col gap-2 mt-1.5">
-              {REFINEMENT_FILTER_GROUPS.map(({ filterKey, labelKey, options }) => {
-                const selected = filterState[filterKey]
-                const isSpecial = filterKey === 'special'
-                return (
-                  <div key={filterKey} className="flex flex-col gap-1">
-                    <span className="text-[10px] text-muted-foreground">
-                      {t(labelKey)}
-                    </span>
-                    <div className={isSpecial ? 'grid grid-cols-[repeat(auto-fill,minmax(7rem,1fr))] gap-1' : 'grid grid-cols-[repeat(auto-fill,minmax(5.5rem,1fr))] gap-1'}>
-                      {options.map((v) => {
-                        const isSelected = selected.includes(v)
-                        return (
-                          <FilterChip
-                            key={v}
-                            value={v}
-                            label={t('equipStats.' + v)}
-                            isValid={true}
-                            isSelected={isSelected}
-                            onToggle={() => toggleFilter(filterKey, v)}
-                          />
-                        )
-                      })}
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-        </div>
-      </div>
-
+      {/* Attribute filter — collapsible (shared FilterPanel/FilterGroup) */}
+      <FilterPanel
+        title={t('refinement.attributeFilters')}
+        collapsed={filterCollapsed}
+        onToggle={toggleFilterCollapsed}
+        activeCount={activeFilterCount}
+        onClear={clearFilters}
+        clearLabel={t('refinement.clearFilters')}
+      >
+        {REFINEMENT_FILTER_GROUPS.map(({ filterKey, labelKey, options }) => (
+          <FilterGroup
+            key={filterKey}
+            label={t(labelKey)}
+            chipColumnClass={filterKey === 'special' ? 'grid-cols-[repeat(auto-fill,minmax(7rem,1fr))]' : undefined}
+            chips={options.map((v) => ({
+              key: v,
+              label: t('equipStats.' + v),
+              valid: true,
+              selected: filterState[filterKey].includes(v),
+              onToggle: () => toggleFilter(filterKey, v),
+            }))}
+          />
+        ))}
+      </FilterPanel>
       {/* Grouped equip list */}
       {groupedSets.length > 0 ? (
         <div className="flex flex-col gap-2">

--- a/src/components/shared/filter-group.test.tsx
+++ b/src/components/shared/filter-group.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { FilterGroup } from './filter-group'
+
+afterEach(cleanup)
+
+it('renders the group label and one chip per option', () => {
+  render(
+    <FilterGroup
+      label="副属性1"
+      chips={[
+        { key: '41', label: '智识', valid: true, selected: false, onToggle: () => {} },
+        { key: '42', label: '意志', valid: true, selected: false, onToggle: () => {} },
+      ]}
+    />,
+  )
+  expect(screen.getByText('副属性1')).toBeTruthy()
+  expect(screen.getByRole('button', { name: '智识' })).toBeTruthy()
+  expect(screen.getByRole('button', { name: '意志' })).toBeTruthy()
+})
+
+it('fires onToggle and reflects the selected state', () => {
+  const onToggle = vi.fn()
+  render(
+    <FilterGroup
+      label="副属性1"
+      chips={[
+        { key: '41', label: '智识', valid: true, selected: true, onToggle },
+      ]}
+    />,
+  )
+  const chip = screen.getByRole('button', { name: '智识' })
+  expect(chip.getAttribute('aria-pressed')).toBe('true')
+  fireEvent.click(chip)
+  expect(onToggle).toHaveBeenCalledTimes(1)
+})
+
+it('applies the default chip column grid', () => {
+  const { container } = render(
+    <FilterGroup label="副属性1" chips={[]} />,
+  )
+  const grid = container.querySelector('.grid')
+  expect(grid?.className).toContain('grid-cols-[repeat(auto-fill,minmax(5.5rem,1fr))]')
+})

--- a/src/components/shared/filter-group.tsx
+++ b/src/components/shared/filter-group.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { FilterChip } from '@/components/shared/filter-chip'
+import { cn } from '@/lib/utils'
+
+export interface FilterGroupChip {
+  key: string
+  label: string
+  valid: boolean
+  selected: boolean
+  onToggle: () => void
+}
+
+export interface FilterGroupProps {
+  /** 组标签 (如 "副属性1")。 */
+  label: string
+  chips: FilterGroupChip[]
+  /** chip 网格类名, 默认 minmax(5.5rem,1fr); 长/短文本组可覆盖。 */
+  chipColumnClass?: string
+}
+
+/**
+ * 单组筛选: 组标签 + FilterChip 网格。
+ * 五处筛选共用的统一实现 (见 filter-panel.tsx 的容器)。
+ */
+export function FilterGroup({
+  label,
+  chips,
+  chipColumnClass = 'grid-cols-[repeat(auto-fill,minmax(5.5rem,1fr))]',
+}: FilterGroupProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] text-muted-foreground">{label}</span>
+      <div className={cn('grid gap-1', chipColumnClass)}>
+        {chips.map((chip) => (
+          <FilterChip
+            key={chip.key}
+            value={chip.key}
+            label={chip.label}
+            isValid={chip.valid}
+            isSelected={chip.selected}
+            onToggle={chip.onToggle}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default FilterGroup

--- a/src/components/shared/filter-panel.test.tsx
+++ b/src/components/shared/filter-panel.test.tsx
@@ -19,6 +19,9 @@ it('toggles the collapse animation classes and fires onToggle', () => {
   const animated = container.querySelector('.grid.transition-all')
   expect(animated?.className).toContain('grid-rows-[0fr]')
   expect(animated?.className).toContain('opacity-0')
+  // 折叠时内容容器 inert: 子树不可交互/不可聚焦。
+  const contentWrap = animated?.querySelector('.overflow-hidden')
+  expect(contentWrap?.hasAttribute('inert')).toBe(true)
 
   fireEvent.click(button)
   expect(onToggle).toHaveBeenCalledTimes(1)
@@ -54,4 +57,17 @@ it('expands with the grid-rows animation when not collapsed', () => {
   const animated = container.querySelector('.grid.transition-all')
   expect(animated?.className).toContain('grid-rows-[1fr]')
   expect(animated?.className).toContain('opacity-100')
+  const contentWrap = animated?.querySelector('.overflow-hidden')
+  expect(contentWrap?.hasAttribute('inert')).toBe(false)
+})
+
+it('renders no clear button when onClear is set without a label', () => {
+  const { container } = render(
+    <FilterPanel title="属性筛选" collapsed={false} onToggle={() => {}} activeCount={2} onClear={() => {}}>
+      <div>内容</div>
+    </FilterPanel>,
+  )
+  expect(container.querySelector('button')).not.toBeNull()
+  // 没有 clearLabel 时不得渲染空标签的清除按钮。
+  expect([...container.querySelectorAll('button')].some((b) => b.textContent.trim() === '')).toBe(false)
 })

--- a/src/components/shared/filter-panel.test.tsx
+++ b/src/components/shared/filter-panel.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { FilterPanel } from './filter-panel'
+
+afterEach(cleanup)
+
+it('toggles the collapse animation classes and fires onToggle', () => {
+  const onToggle = vi.fn()
+  const { container } = render(
+    <FilterPanel title="属性筛选" collapsed onToggle={onToggle}>
+      <div>内容</div>
+    </FilterPanel>,
+  )
+
+  const button = screen.getByRole('button', { name: '属性筛选' })
+  expect(button.getAttribute('aria-expanded')).toBe('false')
+  const animated = container.querySelector('.grid.transition-all')
+  expect(animated?.className).toContain('grid-rows-[0fr]')
+  expect(animated?.className).toContain('opacity-0')
+
+  fireEvent.click(button)
+  expect(onToggle).toHaveBeenCalledTimes(1)
+})
+
+it('shows the active count and clear button only when a filter is active', () => {
+  const onClear = vi.fn()
+  const { container, rerender } = render(
+    <FilterPanel title="属性筛选" collapsed={false} onToggle={() => {}} activeCount={0} onClear={onClear} clearLabel="清除">
+      <div>内容</div>
+    </FilterPanel>,
+  )
+  expect(screen.queryByText('0')).toBeNull()
+  expect(screen.queryByRole('button', { name: '清除' })).toBeNull()
+
+  rerender(
+    <FilterPanel title="属性筛选" collapsed={false} onToggle={() => {}} activeCount={2} onClear={onClear} clearLabel="清除">
+      <div>内容</div>
+    </FilterPanel>,
+  )
+  expect(screen.getByText('2')).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: '清除' }))
+  expect(onClear).toHaveBeenCalledTimes(1)
+  void container
+})
+
+it('expands with the grid-rows animation when not collapsed', () => {
+  const { container } = render(
+    <FilterPanel title="属性筛选" collapsed={false} onToggle={() => {}}>
+      <div>内容</div>
+    </FilterPanel>,
+  )
+  const animated = container.querySelector('.grid.transition-all')
+  expect(animated?.className).toContain('grid-rows-[1fr]')
+  expect(animated?.className).toContain('opacity-100')
+})

--- a/src/components/shared/filter-panel.tsx
+++ b/src/components/shared/filter-panel.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export interface FilterPanelProps {
+  /** 折叠按钮标题。 */
+  title: string
+  collapsed: boolean
+  onToggle: () => void
+  /** 激活筛选计数 (0 或未传时不显示)。 */
+  activeCount?: number
+  /** 清除全部 (未传时不显示清除按钮)。 */
+  onClear?: () => void
+  clearLabel?: string
+  children: ReactNode
+}
+
+/**
+ * 可折叠筛选面板: 折叠按钮 + 激活计数/清除 + 展开/收起动画。
+ * 五处筛选 (精锻 / 基质 / wiki 装备 / 面板预览 / 武器选择器) 共用的统一实现,
+ * 展开动画用 grid-rows 0fr→1fr + opacity, 高度由内容自适应。
+ */
+export function FilterPanel({
+  title,
+  collapsed,
+  onToggle,
+  activeCount = 0,
+  onClear,
+  clearLabel,
+  children,
+}: FilterPanelProps) {
+  return (
+    <div>
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={onToggle}
+        aria-expanded={!collapsed}
+        className="flex min-h-10 w-full items-center gap-2 px-3 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronDown className={cn('size-4 transition-transform', collapsed ? '-rotate-90' : 'rotate-0')} />
+        <span className="flex-1 text-left">{title}</span>
+        {activeCount > 0 && <span className="font-geist-mono text-xs">{activeCount}</span>}
+      </Button>
+      {activeCount > 0 && onClear && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={onClear}
+          className="-mt-0.5 h-auto px-1 text-[10px] text-muted-foreground hover:text-foreground"
+        >
+          {clearLabel}
+        </Button>
+      )}
+      <div
+        className={cn(
+          'grid transition-all duration-200 ease-out',
+          collapsed ? 'grid-rows-[0fr] opacity-0' : 'grid-rows-[1fr] opacity-100',
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="mt-1.5 flex flex-col gap-2">{children}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default FilterPanel

--- a/src/components/shared/filter-panel.tsx
+++ b/src/components/shared/filter-panel.tsx
@@ -45,7 +45,7 @@ export function FilterPanel({
         <span className="flex-1 text-left">{title}</span>
         {activeCount > 0 && <span className="font-geist-mono text-xs">{activeCount}</span>}
       </Button>
-      {activeCount > 0 && onClear && (
+      {activeCount > 0 && onClear && clearLabel && (
         <Button
           type="button"
           variant="ghost"
@@ -62,7 +62,8 @@ export function FilterPanel({
           collapsed ? 'grid-rows-[0fr] opacity-0' : 'grid-rows-[1fr] opacity-100',
         )}
       >
-        <div className="overflow-hidden">
+        {/* inert: 折叠时整个筛选子树不可交互/不可聚焦, 替代 aria-hidden (内容仍需被读屏读取)。 */}
+        <div className="overflow-hidden" inert={collapsed || undefined}>
           <div className="mt-1.5 flex flex-col gap-2">{children}</div>
         </div>
       </div>

--- a/src/components/shared/wiki-entity-picker.tsx
+++ b/src/components/shared/wiki-entity-picker.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { useMemo, useState, type ReactNode } from 'react'
-import { Check, ChevronDown, Search } from 'lucide-react'
+import { Check, Search } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { FilterChip } from '@/components/shared/filter-chip'
+import { FilterGroup } from '@/components/shared/filter-group'
+import { FilterPanel } from '@/components/shared/filter-panel'
 import { PlannerPreviewTooltip } from '@/components/shared/planner-preview-tooltip'
 import { RarityFrame } from '@/components/shared/rarity-frame'
 import { sortWikiEntities } from '@/components/wiki/wiki-entity-grid'
@@ -90,29 +90,36 @@ export function WikiEntityPicker({ title, entities, imageBasePath, selectedIds, 
         <Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder={t('wiki.searchPlaceholder')} aria-label={t('wiki.searchPlaceholder')} className="pl-8" />
       </div>
       {filters.length > 0 && (
-        <div className="space-y-2">
-          <Button type="button" variant="ghost" size="sm" className="w-full justify-start" aria-expanded={filtersOpen} onClick={() => setFiltersOpen((open) => !open)}>
-            <ChevronDown className={filtersOpen ? 'transition-transform' : '-rotate-90 transition-transform'} />
-            {t('wiki.filterToggle')}
-            {activeCount > 0 && <Badge variant="secondary" className="ml-auto">{activeCount}</Badge>}
-          </Button>
-          {filtersOpen && (
-            <div className="space-y-3 rounded-lg bg-muted/35 p-3 shadow-[var(--shadow-border)]">
-              {filters.map((filter) => (
-                <div key={filter.field} className="grid min-w-0 gap-2 sm:grid-cols-[7rem_minmax(0,1fr)] sm:items-start">
-                  <span className="pt-1 text-xs font-medium text-muted-foreground">{t(filter.labelKey)}</span>
-                  <div className="grid min-w-0 grid-cols-[repeat(auto-fill,minmax(6rem,1fr))] gap-1.5">
-                    {(filterValues[filter.field] ?? []).map((value) => {
-                      const values = activeFilters[filter.field] ?? []
-                      return <FilterChip key={value} value={value} label={filter.field === 'rarity' ? `${value}★` : enumLabel(filter.enumGroup, value)} isValid isSelected={values.includes(value)} onToggle={() => setActiveFilters((current) => ({ ...current, [filter.field]: values.includes(value) ? values.filter((entry) => entry !== value) : [...values, value] }))} />
-                    })}
-                  </div>
-                </div>
-              ))}
-              {activeCount > 0 && <Button type="button" variant="ghost" size="sm" onClick={() => setActiveFilters({})}>{t('wiki.clearFilters')}</Button>}
-            </div>
-          )}
-        </div>
+        <FilterPanel
+          title={t('wiki.filterToggle')}
+          collapsed={!filtersOpen}
+          onToggle={() => setFiltersOpen((open) => !open)}
+          activeCount={activeCount}
+          onClear={() => setActiveFilters({})}
+          clearLabel={t('wiki.clearFilters')}
+        >
+          {filters.map((filter) => {
+            const selectedValues = activeFilters[filter.field] ?? []
+            return (
+              <FilterGroup
+                key={filter.field}
+                label={t(filter.labelKey)}
+                chips={(filterValues[filter.field] ?? []).map((value) => ({
+                  key: value,
+                  label: filter.field === 'rarity' ? `${value}★` : enumLabel(filter.enumGroup, value),
+                  valid: true,
+                  selected: selectedValues.includes(value),
+                  onToggle: () => setActiveFilters((current) => ({
+                    ...current,
+                    [filter.field]: selectedValues.includes(value)
+                      ? selectedValues.filter((entry) => entry !== value)
+                      : [...selectedValues, value],
+                  })),
+                }))}
+              />
+            )
+          })}
+        </FilterPanel>
       )}
       <div className={cn('grid content-start items-start grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-2', gridClassName)}>
         {filtered.map((entity) => {

--- a/src/components/wiki/wiki-entity-grid.test.ts
+++ b/src/components/wiki/wiki-entity-grid.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from 'vitest'
 import {
   defaultExpandedWikiGroups,
+  filterValue,
   getWikiEntityUpStatus,
   getWikiEquipmentModelKey,
   groupWikiEntities,
@@ -293,4 +294,26 @@ it('renders the sticky group header inside the scroll container, opaque and abov
   expect(WIKI_GROUP_HEADER_CLASS).toContain('z-30')
   // var(--border) flips with .dark so the hairline survives in dark mode.
   expect(WIKI_GROUP_HEADER_CLASS).toContain('shadow-[0_1px_0_0_var(--border)]')
+})
+
+it('resolves refinement sub-attribute filters for equipment only', () => {
+  // 5★ 装备: 属性 key 来自 equipSubAttrsById。
+  const fiveStar: WikiEquipmentSummary = {
+    ...({} as WikiEquipmentSummary),
+    id: 'item_equip_t4_suit_atk02_edc_05',
+    category: 'equipment',
+    name: localized('50式应龙短刃·壹型', 'Type 50 Yinglung Knife T1'),
+    rarity: 5,
+    imageId: 'item_equip_t4_suit_atk02_edc_05',
+    partTypeId: '2',
+    minimumLevel: 70,
+  }
+  expect(filterValue(fiveStar, 'sub1')).toBe('41')
+  expect(filterValue(fiveStar, 'sub2')).toBe('39')
+  expect(filterValue(fiveStar, 'special')).toBe('AllSkillDamageIncrease')
+
+  // 非 5★ (无精锻数据) 与非装备实体返回空串, 不参与属性筛选。
+  expect(filterValue(idSearchEquipment, 'sub1')).toBe('')
+  const weapon = { id: 'wpn', category: 'weapons' as const, name: localized('剑', 'Sword'), rarity: 6, imageId: 'wpn', weaponTypeId: '1', maxLevel: 90 }
+  expect(filterValue(weapon, 'sub1')).toBe('')
 })

--- a/src/components/wiki/wiki-entity-grid.test.ts
+++ b/src/components/wiki/wiki-entity-grid.test.ts
@@ -317,3 +317,11 @@ it('resolves refinement sub-attribute filters for equipment only', () => {
   const weapon = { id: 'wpn', category: 'weapons' as const, name: localized('剑', 'Sword'), rarity: 6, imageId: 'wpn', weaponTypeId: '1', maxLevel: 90 }
   expect(filterValue(weapon, 'sub1')).toBe('')
 })
+
+it('resolves the rarity filter from the entity rarity for every category', () => {
+  expect(filterValue({ ...idSearchEquipment, rarity: 4 }, 'rarity')).toBe('4')
+  const weapon = { id: 'wpn', category: 'weapons' as const, name: localized('剑', 'Sword'), rarity: 6, imageId: 'wpn', weaponTypeId: '1', maxLevel: 90 }
+  expect(filterValue(weapon, 'rarity')).toBe('6')
+  const char = { ...character('chr', '干员', 6) }
+  expect(filterValue(char, 'rarity')).toBe('6')
+})

--- a/src/components/wiki/wiki-entity-grid.tsx
+++ b/src/components/wiki/wiki-entity-grid.tsx
@@ -11,11 +11,13 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { RarityFrame } from '@/components/shared/rarity-frame'
 import { getRarityColorClass, normalizeRarity } from '@/components/shared/rarity-stars'
-import { FilterChip } from '@/components/shared/filter-chip'
+import { FilterGroup } from '@/components/shared/filter-group'
+import { FilterPanel } from '@/components/shared/filter-panel'
 import { NavLink } from '@/components/shared/nav-link'
 import { cn } from '@/lib/utils'
 import { withImageCacheVersion } from '@/lib/image-url'
 import { useWikiTranslations } from '@/hooks/use-wiki-translations'
+import { equipSubAttrKey } from '@/lib/equip-substats'
 import { useWikiStore } from '@/stores/useWikiStore'
 import type {
   WikiEntitySummary,
@@ -35,6 +37,9 @@ type WikiFilterField =
   | 'professionId'
   | 'weaponTypeId'
   | 'partTypeId'
+  | 'sub1'
+  | 'sub2'
+  | 'special'
 
 type WikiGroupField = 'elementId' | 'weaponTypeId'
 
@@ -42,6 +47,11 @@ interface WikiEntityFilter {
   field: WikiFilterField
   labelKey: string
   enumGroup?: WikiEnumGroup
+  /**
+   * 筛选值标签的 i18n 前缀 (如 'equipStats'): chip 与空态条件用 t(`${prefix}.${value}`) 解析。
+   * RSC 边界不能传函数, 因此用命名空间字符串; 未提供时回退到 enumGroup / 原始值。
+   */
+  labelPrefix?: string
 }
 
 interface WikiEntityGroupConfig {
@@ -99,12 +109,15 @@ const CARD_GRID_CLASS =
 export const WIKI_GROUP_HEADER_CLASS =
   'sticky top-0 z-30 flex min-w-0 items-center gap-2 bg-card px-1 py-1 shadow-[0_1px_0_0_var(--border)]'
 
-function filterValue(entity: GridEntity, field: WikiFilterField): string {
-  if (field === 'rarity') return String(entity.rarity)
+export function filterValue(entity: GridEntity, field: WikiFilterField): string {
   if (field === 'elementId') return entity.category === 'characters' ? entity.elementId : ''
   if (field === 'professionId') return entity.category === 'characters' ? entity.professionId : ''
   if (field === 'weaponTypeId') {
     return entity.category === 'equipment' ? '' : entity.weaponTypeId
+  }
+  // 精锻属性筛选仅对装备生效: 5★ 装备在 equipSubAttrsById 有记录, 其余返回空串。
+  if (field === 'sub1' || field === 'sub2' || field === 'special') {
+    return entity.category === 'equipment' ? equipSubAttrKey(entity.id, field) : ''
   }
   return entity.category === 'equipment' ? entity.partTypeId : ''
 }
@@ -329,6 +342,18 @@ export const WikiEntityGrid = memo(function WikiEntityGrid({
   const refreshBannerStatus = useBannerStore((state) => state.refreshBannerStatus)
   const upNames = useMemo(() => new Set(upCharacterNames), [upCharacterNames])
 
+  /**
+   * 筛选值的展示标签: labelPrefix → i18n (如 equipStats.41 → 智识);
+   * 否则回退到稀有度 / enumGroup / 原始值。
+   */
+  const valueLabel = useCallback(
+    (filter: WikiEntityFilter, value: string) => {
+      if (filter.labelPrefix) return t(`${filter.labelPrefix}.${value}`)
+      if (filter.field === 'rarity') return `${value}★`
+      return filter.enumGroup ? labelFor(filter.enumGroup, value) : value
+    },
+    [labelFor, t],
+  )
   useEffect(() => setHydrated(true), [])
 
   useEffect(() => {
@@ -351,13 +376,13 @@ export const WikiEntityGrid = memo(function WikiEntityGrid({
             return (leftIndex < 0 ? Number.MAX_SAFE_INTEGER : leftIndex) - (rightIndex < 0 ? Number.MAX_SAFE_INTEGER : rightIndex)
           }
         }
-        const leftLabel = filter.enumGroup ? labelFor(filter.enumGroup, left) : left
-        const rightLabel = filter.enumGroup ? labelFor(filter.enumGroup, right) : right
+        const leftLabel = valueLabel(filter, left)
+        const rightLabel = valueLabel(filter, right)
         return leftLabel.localeCompare(rightLabel, locale)
       })
     }
     return result
-  }, [entities, enumOrder, filters, labelFor, locale])
+  }, [entities, enumOrder, filters, locale, valueLabel])
 
   const searchTerm = deferredSearch.trim()
 
@@ -394,12 +419,11 @@ export const WikiEntityGrid = memo(function WikiEntityGrid({
     for (const filter of filters) {
       const selected = activeFilters[filter.field]
       if (!selected || selected.size === 0) continue
-      const values = [...selected].map((value) =>
-        filter.field === 'rarity' ? `${value}★` : filter.enumGroup ? labelFor(filter.enumGroup, value) : value)
+      const values = [...selected].map((value) => valueLabel(filter, value))
       conditions.push(`${t(filter.labelKey)}: ${values.join(' / ')}`)
     }
     return conditions
-  }, [activeFilters, filters, labelFor, searchTerm, t])
+  }, [activeFilters, filters, searchTerm, t, valueLabel])
   const filteredEquipment = useMemo(
     () => filtered.filter((entity): entity is GridEntity & { category: 'equipment'; partTypeId: string } => entity.category === 'equipment'),
     [filtered]
@@ -544,45 +568,28 @@ export const WikiEntityGrid = memo(function WikiEntityGrid({
           </div>
         </div>
         {filters.length > 0 && (
-          <div className="flex flex-col gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              aria-expanded={filterPanelOpen}
-              onClick={() => setFilterPanelOpen((open) => !open)}
-              className="min-h-10 w-full justify-start gap-2 px-3 text-sm text-muted-foreground hover:text-foreground"
-            >
-              <ChevronDown className={filterPanelOpen ? 'transition-transform' : '-rotate-90 transition-transform'} />
-              <span>{t('wiki.filterToggle')}</span>
-              {activeFilterCount > 0 && <Badge variant="secondary" className="ml-auto">{activeFilterCount}</Badge>}
-            </Button>
-            {filterPanelOpen && (
-              <div className="space-y-3 rounded-lg bg-muted/30 p-3 shadow-[var(--shadow-border)]">
-                {filters.map((filter) => (
-                  <div key={filter.field} className="grid min-w-0 gap-2 sm:grid-cols-[7rem_minmax(0,1fr)] sm:items-start">
-                    <span className="pt-1 text-xs font-medium text-muted-foreground">{t(filter.labelKey)}</span>
-                    <div className="grid min-w-0 grid-cols-[repeat(auto-fill,minmax(6rem,1fr))] gap-1.5">
-                      {filterValues[filter.field]?.map((value) => (
-                        <FilterChip
-                          key={value}
-                          value={value}
-                          label={filter.field === 'rarity' ? `${value}★` : filter.enumGroup ? labelFor(filter.enumGroup, value) : value}
-                          isValid
-                          isSelected={activeFilters[filter.field]?.has(value) ?? false}
-                          onToggle={() => toggleFilter(filter.field, value)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                ))}
-                {hasActiveFilters && (
-                  <Button type="button" variant="ghost" size="sm" onClick={() => setActiveFilters({})}>
-                    {t('wiki.clearFilters')}
-                  </Button>
-                )}
-              </div>
-            )}
-          </div>
+          <FilterPanel
+            title={t('wiki.filterToggle')}
+            collapsed={!filterPanelOpen}
+            onToggle={() => setFilterPanelOpen((open) => !open)}
+            activeCount={activeFilterCount}
+            onClear={() => setActiveFilters({})}
+            clearLabel={t('wiki.clearFilters')}
+          >
+            {filters.map((filter) => (
+              <FilterGroup
+                key={filter.field}
+                label={t(filter.labelKey)}
+                chips={(filterValues[filter.field] ?? []).map((value) => ({
+                  key: value,
+                  label: valueLabel(filter, value),
+                  valid: true,
+                  selected: activeFilters[filter.field]?.has(value) ?? false,
+                  onToggle: () => toggleFilter(filter.field, value),
+                }))}
+              />
+            ))}
+          </FilterPanel>
         )}
       </div>
 

--- a/src/components/wiki/wiki-entity-grid.tsx
+++ b/src/components/wiki/wiki-entity-grid.tsx
@@ -110,6 +110,7 @@ export const WIKI_GROUP_HEADER_CLASS =
   'sticky top-0 z-30 flex min-w-0 items-center gap-2 bg-card px-1 py-1 shadow-[0_1px_0_0_var(--border)]'
 
 export function filterValue(entity: GridEntity, field: WikiFilterField): string {
+  if (field === 'rarity') return String(entity.rarity)
   if (field === 'elementId') return entity.category === 'characters' ? entity.elementId : ''
   if (field === 'professionId') return entity.category === 'characters' ? entity.professionId : ''
   if (field === 'weaponTypeId') {

--- a/src/i18n/load-messages.test.ts
+++ b/src/i18n/load-messages.test.ts
@@ -44,7 +44,7 @@ it('route shell messages resolve namespaces and picks per route', () => {
   const wiki = loadRouteShellMessages('ja', 'wiki') as Record<string, Record<string, unknown>>
   expect(wiki).toHaveProperty('wiki')
   expect(Object.keys(wiki.refinement).sort()).toEqual(
-    ['modelTypeI', 'modelTypeII', 'modelTypeIII'].sort(),
+    ['modelTypeI', 'modelTypeII', 'modelTypeIII', 'specialEffect', 'subAttr1', 'subAttr2'].sort(),
   )
 
   const login = loadRouteShellMessages('en', 'login') as Record<string, unknown>
@@ -92,9 +92,14 @@ it('planner catalogs can be sliced per route profile', () => {
   expect(Object.keys(account).sort()).toEqual(['equips', 'region'])
 
   // Panel preview needs weaponStats so weaponStatLabel() can resolve
-  // weapon attribute ids (gat_passive_attr_*, gst_passive_*) via t('weaponStats.<id>').
+  // weapon attribute ids (gat_passive_attr_*, gst_passive_*) via t('weaponStats.<id>'),
+  // plus equipStats for the equipment picker's refinement sub-attribute chips.
   const panelPreview = loadPlannerCatalogs('zh-CN', 'panel-preview') as Record<string, unknown>
-  expect(Object.keys(panelPreview).sort()).toEqual(['weaponStats'])
+  expect(Object.keys(panelPreview).sort()).toEqual(['equipStats', 'weaponStats'])
+
+  // Wiki: 装备页精锻属性筛选 chips 的属性名 (equipStats.41 → 智识)。
+  const wiki = loadPlannerCatalogs('zh-CN', 'wiki') as Record<string, unknown>
+  expect(Object.keys(wiki).sort()).toEqual(['equipStats'])
 })
 
 it('planner client messages include shell + selected catalogs but not wikiData', () => {

--- a/src/i18n/load-messages.ts
+++ b/src/i18n/load-messages.ts
@@ -148,6 +148,7 @@ export type PlannerCatalogProfile =
   | 'essence'
   | 'refinement'
   | 'panel-preview'
+  | 'wiki'
   | 'account'
 
 const PLANNER_CATALOG_KEYS = {
@@ -168,8 +169,10 @@ const PLANNER_CATALOG_KEYS = {
   essence: ['weapons', 'dungeons', 'gemStats', 'weaponStats', 'region'],
   /** Refinement planner: equipment tables only. */
   refinement: ['equips', 'equipStats', 'equipTypes', 'suits', 'materials'],
-  /** Panel preview: weapon stat labels (weaponStats) for the weapon tooltip config. */
-  'panel-preview': ['weaponStats'],
+  /** Panel preview: weapon stat labels (weaponStats) + equipment sub-attribute chips (equipStats). */
+  'panel-preview': ['weaponStats', 'equipStats'],
+  /** Wiki: 装备页精锻属性筛选 chips 的属性名 (equipStats.41 → 智识)。 */
+  wiki: ['equipStats'],
   /** Account sync conflict UI: equip display names + region labels (settings diff). */
   account: ['equips', 'region'],
 } as const satisfies Record<PlannerCatalogProfile, readonly (keyof CatalogBag)[]>

--- a/src/i18n/route-shell-messages.json
+++ b/src/i18n/route-shell-messages.json
@@ -77,7 +77,7 @@
         ]
       }
     },
-    "panel-preview": { "namespaces": ["panelPreview", "wiki"], "catalogs": ["weaponStats"] },
+    "panel-preview": { "namespaces": ["panelPreview", "wiki"], "catalogs": ["weaponStats", "equipStats"], "picks": { "refinement": ["attributeFilters", "clearFilters", "subAttr1", "subAttr2", "specialEffect"], "essence": ["anyAttribute"] } },
     "refinement-planner": {
       "namespaces": ["refinement", "wiki"],
       "picks": { "meta": ["refinementPlannerDescription"] },
@@ -88,7 +88,7 @@
     "update": { "namespaces": ["version"] },
     "wiki": {
       "namespaces": ["wiki"],
-      "picks": { "refinement": ["modelTypeI", "modelTypeII", "modelTypeIII"] }
+      "picks": { "refinement": ["modelTypeI", "modelTypeII", "modelTypeIII", "subAttr1", "subAttr2", "specialEffect"] }
     }
   }
 }

--- a/src/lib/equip-substats.test.ts
+++ b/src/lib/equip-substats.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { equipSubAttrKey, equipSubAttrsById } from './equip-substats'
+
+describe('equipSubAttrsById', () => {
+  it('maps five-star equip ids to their sub-attribute keys', () => {
+    // 50式应龙短刃·壹型: sub1 '41+32' → '41' (智识), sub2 '39+21' → '39' (力量),
+    // special 'AllSkillDamageIncrease+27.6%' → 'AllSkillDamageIncrease'
+    const attrs = equipSubAttrsById.get('item_equip_t4_suit_atk02_edc_05')
+    expect(attrs).toEqual({ sub1: '41', sub2: '39', special: 'AllSkillDamageIncrease' })
+  })
+
+  it('omits slots without data', () => {
+    // 点剑定位信标 sub2 为空。
+    const attrs = equipSubAttrsById.get('item_equip_t4_suit_phy01_edc_01')
+    expect(attrs?.sub1).toBe('39')
+    expect(attrs?.sub2).toBeUndefined()
+  })
+
+  it('returns an empty string for unknown or non-five-star ids', () => {
+    expect(equipSubAttrKey('item_equip_t0_parts_tundra01_body_01', 'sub1')).toBe('')
+    expect(equipSubAttrKey('not-a-real-id', 'special')).toBe('')
+  })
+})

--- a/src/lib/equip-substats.ts
+++ b/src/lib/equip-substats.ts
@@ -1,0 +1,26 @@
+import { equips } from '@/data/equips'
+
+export type EquipSubSlot = 'sub1' | 'sub2' | 'special'
+
+export type EquipSubAttrs = Partial<Record<EquipSubSlot, string>>
+
+/**
+ * 装备 id → 精锻属性 key (sub1/sub2/special 的属性标识符)。
+ * 数据来自 src/data/equips.ts (旧数据集, 仅覆盖 5★ 装备, id 与 wiki 装备一一对应);
+ * 1–4★ 装备无记录, 查询返回空串, 天然不参与属性筛选。
+ */
+export const equipSubAttrsById: ReadonlyMap<string, EquipSubAttrs> = new Map(
+  equips.map((equip) => [
+    equip.id,
+    {
+      ...(equip.sub1?.key ? { sub1: equip.sub1.key } : {}),
+      ...(equip.sub2?.key ? { sub2: equip.sub2.key } : {}),
+      ...(equip.special?.key ? { special: equip.special.key } : {}),
+    },
+  ]),
+)
+
+/** 装备在指定槽位的属性 key; 无数据 (1–4★ 或未知 id) 返回空串。 */
+export function equipSubAttrKey(equipId: string, slot: EquipSubSlot): string {
+  return equipSubAttrsById.get(equipId)?.[slot] ?? ''
+}


### PR DESCRIPTION
## Summary by Sourcery

统一精炼、Essence、Wiki 网格、武器与实体选择器以及面板预览中的属性筛选 UI，使用共享组件实现一致体验，并在 Wiki 与面板预览流程中为装备增加精炼子属性筛选功能。

New Features:
- 新增共享的 `FilterPanel` 和 `FilterGroup` 组件，提供可复用的、可折叠的 Chip 式筛选 UI。
- 为装备在 Wiki 装备页面和面板预览的装备套装选择器中引入精炼子属性筛选（`sub1`、`sub2`、`special`），由共享的 `equipSubstats` 映射提供支持。

Enhancements:
- 优化 Wiki 实体网格中的筛选标签解析，使筛选值可以通过可配置的 i18n 前缀（例如 `equipStats`）实现本地化。
- 更新精炼装备列表、武器网格、Wiki 实体选择器和 Wiki 实体网格，以使用新的共享筛选组件，取代各自的定制实现。

Tests:
- 为 `FilterPanel` 和 `FilterGroup` 组件、装备子属性工具函数、Wiki 实体网格中的精炼筛选解析逻辑，以及装备套装选择器中的精炼筛选行为添加单元测试。
- 扩展 i18n 加载测试，以覆盖新的精炼与 `equipStats` 键，以及 Wiki/面板预览的目录配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify attribute filter UI across refinement, essence, wiki grids, weapon and entity pickers, and panel preview using shared components, and add refinement sub-attribute filtering for equipment in the wiki and panel preview flows.

New Features:
- Add shared FilterPanel and FilterGroup components to provide a reusable collapsible chip-based filtering UI.
- Introduce refinement sub-attribute filters (sub1, sub2, special) for equipment in the wiki equipment page and panel-preview equipment suit picker, backed by a shared equipSubstats mapping.

Enhancements:
- Refine filter label resolution in the wiki entity grid so filter values can be localized via a configurable i18n prefix (e.g., equipStats).
- Update refinement equip list, weapon grid, wiki entity picker, and wiki entity grid to consume the new shared filter components instead of bespoke implementations.

Tests:
- Add unit tests for FilterPanel and FilterGroup components, the equip-substats utilities, wiki entity grid refinement filter resolution, and equipment suit picker refinement filtering behavior.
- Extend i18n loading tests to cover new refinement and equipStats keys and wiki/panel-preview catalog profiles.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
- 装备 Wiki、装备套装选择器和精锻装备列表新增精锻属性筛选，支持副属性 1、副属性 2 和特殊属性多选。
- 筛选面板支持折叠展开、显示已选数量及一键清除。
- Wiki 与装备预览新增相关属性标签和本地化内容。
- 统一筛选控件样式，提升不同页面的筛选体验。

## 测试
- 新增并完善精锻属性筛选、筛选面板、筛选组及属性解析相关测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->