### PR TITLE
调整侧边栏布局，减少被大幅遮挡的情况

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -121,7 +121,7 @@ export function AppSidebar() {
 
   const refreshBtnRef = useRef<HTMLDivElement>(null);
   const [popupPos, setPopupPos] = useState({ top: 0, left: 0 });
-  const { canScrollUp, canScrollDown, contentRef, handleScroll } =
+  const { canScrollUp, canScrollDown, contentRef, contentInnerRef, handleScroll } =
     useSidebarScrollState();
 
   const updatePopupPos = useCallback(() => {
@@ -243,6 +243,8 @@ export function AppSidebar() {
             onScroll={handleScroll}
             className="h-full"
           >
+            {/* 内容层供 ResizeObserver 监听 scrollHeight（子项增减/结构切换） */}
+            <div ref={contentInnerRef} className="flex shrink-0 flex-col">
             <SidebarGroup>
               <SidebarGroupLabel className="group-data-[collapsible=icon]:pointer-events-none">
                 {t("nav.groupModules")}
@@ -397,11 +399,13 @@ export function AppSidebar() {
                 })}
               </SidebarMenu>
             </SidebarGroup>
+            </div>
           </SidebarContent>
-          {canScrollUp && (
+          {/* collapsed 图标模式下内容 overflow-hidden、无法滚动，渐隐会误导为“还有内容” */}
+          {(isMobile || state !== "collapsed") && canScrollUp && (
             <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-5 bg-gradient-to-b from-sidebar to-transparent" />
           )}
-          {canScrollDown && (
+          {(isMobile || state !== "collapsed") && canScrollDown && (
             <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-5 bg-gradient-to-t from-sidebar to-transparent" />
           )}
         </div>
@@ -429,14 +433,10 @@ export function AppSidebar() {
                   createPortal(
                     <div
                       style={{
-                        position: "fixed",
                         top: popupPos.top,
                         left: popupPos.left,
-                        transform: "translateY(-50%)",
-                        transition: "top 0.3s ease, left 0.3s ease",
-                        zIndex: 9999,
                       }}
-                      className="bg-amber-500 text-white px-3 py-1.5 rounded-md text-sm font-medium shadow-[0_0_18px_rgba(245,158,11,0.5)] transition-transform hover:scale-105 whitespace-nowrap"
+                      className="fixed z-[9999] -translate-y-1/2 transition-[top,left,transform] duration-300 ease-[ease] bg-amber-500 text-white px-3 py-1.5 rounded-md text-sm font-medium shadow-[0_0_18px_rgba(245,158,11,0.5)] hover:scale-105 whitespace-nowrap"
                     >
                       {/* Arrow pointing left toward the button */}
                       <div className="absolute left-[-6px] top-1/2 -translate-y-1/2 w-0 h-0 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent border-r-[6px] border-r-amber-500" />

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,11 +1,17 @@
-'use client'
+"use client";
 
-import { useState, useEffect, useRef, useCallback, useSyncExternalStore } from 'react'
-import { createPortal } from 'react-dom'
-import Image from 'next/image'
-import { NavLink } from '@/components/shared/nav-link'
-import { usePathname } from 'next/navigation'
-import { useLocale, useTranslations } from 'next-intl'
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useSyncExternalStore,
+} from "react";
+import { createPortal } from "react-dom";
+import Image from "next/image";
+import { NavLink } from "@/components/shared/nav-link";
+import { usePathname } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
 import {
   Sidebar,
   SidebarContent,
@@ -17,8 +23,8 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
-} from '@/components/ui/sidebar'
-import { TooltipProvider } from '@/components/ui/tooltip'
+} from "@/components/ui/sidebar";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   Swords,
   Disc,
@@ -39,399 +45,551 @@ import {
   PanelsTopLeft,
   Languages,
   ExternalLink,
-} from 'lucide-react'
-import { useAuthStore } from '@/stores/useAuthStore'
-import { FEATURES } from '@/lib/features'
-import { useVersion } from '@/hooks/use-version'
-import { useAnnouncementStore, useImportantUnreadCount } from '@/stores/useAnnouncementStore'
-import { cn, formatTime } from '@/lib/utils'
-import { ForceUpgradeDialog } from './shared/force-upgrade-dialog'
-import { AdSlot } from '@/components/shared/ad-slot'
-import { LanguageSwitcher } from '@/components/language-switcher'
+} from "lucide-react";
+import { useAuthStore } from "@/stores/useAuthStore";
+import { FEATURES } from "@/lib/features";
+import { useVersion } from "@/hooks/use-version";
+import {
+  useAnnouncementStore,
+  useImportantUnreadCount,
+} from "@/stores/useAnnouncementStore";
+import { cn, formatTime } from "@/lib/utils";
+import { ForceUpgradeDialog } from "./shared/force-upgrade-dialog";
+import { AdSlot } from "@/components/shared/ad-slot";
+import { LanguageSwitcher } from "@/components/language-switcher";
+import { useSidebarScrollState } from "@/hooks/use-sidebar-scroll-state";
 
 const NAV_ITEMS = [
-  { href: '/essence-planner', label: 'nav.essencePlanner', Icon: Disc },
-  { href: '/refinement-planner', label: 'nav.refinementPlanner', Icon: Wrench },
-  { href: '/growth-planner', label: 'nav.growthPlanner', Icon: ChartNoAxesCombined },
-  { href: '/panel-preview', label: 'nav.panelPreview', Icon: PanelsTopLeft },
-  { href: '/banner-calendar', label: 'nav.bannerCalendar', Icon: Calendar },
-  ...(FEATURES.forum ? [{ href: '/forum', label: 'nav.forum', Icon: MessageCircle }] : []),
-]
+  { href: "/essence-planner", label: "nav.essencePlanner", Icon: Disc },
+  { href: "/refinement-planner", label: "nav.refinementPlanner", Icon: Wrench },
+  {
+    href: "/growth-planner",
+    label: "nav.growthPlanner",
+    Icon: ChartNoAxesCombined,
+  },
+  { href: "/panel-preview", label: "nav.panelPreview", Icon: PanelsTopLeft },
+  { href: "/banner-calendar", label: "nav.bannerCalendar", Icon: Calendar },
+  ...(FEATURES.forum
+    ? [{ href: "/forum", label: "nav.forum", Icon: MessageCircle }]
+    : []),
+];
 const TOOL_ITEMS = [
-  { href: '/tools/game-i18n', label: 'nav.gameI18nLookup', Icon: Languages },
-  { href: '/background-preview', label: 'nav.backgroundPreview', Icon: ImageDown },
-  { href: 'https://status.canmoe.com/', label: 'nav.siteStatus', Icon: ExternalLink, external: true },
-]
+  { href: "/tools/game-i18n", label: "nav.gameI18nLookup", Icon: Languages },
+  {
+    href: "/background-preview",
+    label: "nav.backgroundPreview",
+    Icon: ImageDown,
+  },
+  {
+    href: "https://status.canmoe.com/",
+    label: "nav.siteStatus",
+    Icon: ExternalLink,
+    external: true,
+  },
+];
 const WIKI_ITEMS = [
-  { href: '/wiki/characters', label: 'wiki.categories.characters', Icon: UsersRound },
-  { href: '/wiki/weapons', label: 'wiki.categories.weapons', Icon: Swords },
-  { href: '/wiki/equipment', label: 'wiki.categories.equipment', Icon: Shirt },
-]
+  {
+    href: "/wiki/characters",
+    label: "wiki.categories.characters",
+    Icon: UsersRound,
+  },
+  { href: "/wiki/weapons", label: "wiki.categories.weapons", Icon: Swords },
+  { href: "/wiki/equipment", label: "wiki.categories.equipment", Icon: Shirt },
+];
 
 export function AppSidebar() {
-  const pathname = usePathname()
-  const locale = useLocale()
-  const t = useTranslations()
-  const { isUpdateAvailable, info, localInfo, forceUpgrade, refreshPage } = useVersion()
-  const { state, setOpenMobile, isMobile } = useSidebar()
-  const mounted = useSyncExternalStore(() => () => {}, () => true, () => false)
+  const pathname = usePathname();
+  const locale = useLocale();
+  const t = useTranslations();
+  const { isUpdateAvailable, info, localInfo, forceUpgrade, refreshPage } =
+    useVersion();
+  const { state, setOpenMobile, isMobile } = useSidebar();
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
 
-  const username = useAuthStore((s) => s.username)
-  const accessToken = useAuthStore((s) => s.accessToken)
-  const sessionExpired = useAuthStore((s) => s.sessionExpired)
-  const announcementTotalUnread = useAnnouncementStore((s) =>
-    s.announcements.filter((a) => !s.readIds.includes(a.id)).length
-  )
-  const announcementImportantUnread = useImportantUnreadCount()
-  const hasImportantUnread = announcementImportantUnread > 0
+  const username = useAuthStore((s) => s.username);
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const sessionExpired = useAuthStore((s) => s.sessionExpired);
+  const announcementTotalUnread = useAnnouncementStore(
+    (s) => s.announcements.filter((a) => !s.readIds.includes(a.id)).length,
+  );
+  const announcementImportantUnread = useImportantUnreadCount();
+  const hasImportantUnread = announcementImportantUnread > 0;
 
-  const refreshBtnRef = useRef<HTMLDivElement>(null)
-  const [popupPos, setPopupPos] = useState({ top: 0, left: 0 })
+  const refreshBtnRef = useRef<HTMLDivElement>(null);
+  const [popupPos, setPopupPos] = useState({ top: 0, left: 0 });
+  const { canScrollUp, canScrollDown, contentRef, handleScroll } =
+    useSidebarScrollState();
 
   const updatePopupPos = useCallback(() => {
-    if (!refreshBtnRef.current) return
-    const rect = refreshBtnRef.current.getBoundingClientRect()
-    setPopupPos({ top: rect.top + rect.height / 2, left: rect.right + 10 })
-  }, [])
+    if (!refreshBtnRef.current) return;
+    const rect = refreshBtnRef.current.getBoundingClientRect();
+    setPopupPos({ top: rect.top + rect.height / 2, left: rect.right + 10 });
+  }, []);
 
   // Post-rehydration auth check. Runs once on mount after zustand
   // rehydration completes. Only when auth feature is enabled.
-  const didHydrateCheck = useRef(false)
+  const didHydrateCheck = useRef(false);
   useEffect(() => {
-    if (!mounted || didHydrateCheck.current || !FEATURES.auth) return
-    didHydrateCheck.current = true
-    const s = useAuthStore.getState()
+    if (!mounted || didHydrateCheck.current || !FEATURES.auth) return;
+    didHydrateCheck.current = true;
+    const s = useAuthStore.getState();
     if (s.accessToken) {
-      s.fetchMe()
+      s.fetchMe();
     } else if (s.username) {
-      useAuthStore.setState({ sessionExpired: true })
+      useAuthStore.setState({ sessionExpired: true });
     }
-  }, [mounted])
+  }, [mounted]);
 
   useEffect(() => {
-    if (!mounted || state !== 'collapsed' || !isUpdateAvailable || !refreshBtnRef.current) return
+    if (
+      !mounted ||
+      state !== "collapsed" ||
+      !isUpdateAvailable ||
+      !refreshBtnRef.current
+    )
+      return;
 
-    const el = refreshBtnRef.current
-    const ro = new ResizeObserver(() => updatePopupPos())
-    ro.observe(el)
+    const el = refreshBtnRef.current;
+    const ro = new ResizeObserver(() => updatePopupPos());
+    ro.observe(el);
 
-    updatePopupPos()
+    updatePopupPos();
 
-    return () => ro.disconnect()
-  }, [mounted, state, isUpdateAvailable, updatePopupPos])
+    return () => ro.disconnect();
+  }, [mounted, state, isUpdateAvailable, updatePopupPos]);
 
-  const versionStr = localInfo?.version ?? info?.version ?? ''
-  const versionMajorMinor = versionStr ? versionStr.split('-')[0].split('.').slice(0, 2).join('.') : ''
-  const versionBuildTime = localInfo?.buildTime ?? info?.buildTime ?? ''
-  const versionBuildTimeText = mounted && versionBuildTime ? formatTime(versionBuildTime) : '--:--'
+  const versionStr = localInfo?.version ?? info?.version ?? "";
+  const versionMajorMinor = versionStr
+    ? versionStr.split("-")[0].split(".").slice(0, 2).join(".")
+    : "";
+  const versionBuildTime = localInfo?.buildTime ?? info?.buildTime ?? "";
+  const versionBuildTimeText =
+    mounted && versionBuildTime ? formatTime(versionBuildTime) : "--:--";
 
   return (
     <TooltipProvider delay={0}>
       <Sidebar collapsible="icon">
-      <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              size="lg"
-              className="overflow-visible"
-              render={<NavLink href={`/${locale}`} loadingLabel={t('app.name')} />}
-              tooltip={t('app.name')}
-              onClick={() => {
-                if (isMobile) setOpenMobile(false)
-              }}
-            >
-              <span className="relative inline-flex shrink-0 overflow-visible">
-                <Image src="/icon.png" alt={t('app.name')} width={32} height={32} className="size-8 rounded-lg" unoptimized />
+        <SidebarHeader>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                size="lg"
+                className="overflow-visible"
+                render={
+                  <NavLink href={`/${locale}`} loadingLabel={t("app.name")} />
+                }
+                tooltip={t("app.name")}
+                onClick={() => {
+                  if (isMobile) setOpenMobile(false);
+                }}
+              >
+                <span className="relative inline-flex shrink-0 overflow-visible">
+                  <Image
+                    src="/icon.png"
+                    alt={t("app.name")}
+                    width={32}
+                    height={32}
+                    className="size-8 rounded-lg"
+                    unoptimized
+                  />
+                  {announcementTotalUnread > 0 && (
+                    <span
+                      className={cn(
+                        "absolute -top-0.5 -right-0.5 size-2.5 rounded-full ring-2 ring-sidebar",
+                        hasImportantUnread ? "bg-amber-500" : "bg-develop-blue",
+                      )}
+                    />
+                  )}
+                </span>
+                {/* 应用名与未读徽章必须是兄弟节点: 放在同一个 span 里时,
+                  span 没有 min-w-0/truncate 而按钮又是 overflow-visible,
+                  长名字(zh-CN)会把徽章一起顶出可视区域。 */}
+                <span className="min-w-0 flex-1 truncate font-semibold">
+                  {t("app.name")}
+                </span>
                 {announcementTotalUnread > 0 && (
                   <span
                     className={cn(
-                      'absolute -top-0.5 -right-0.5 size-2.5 rounded-full ring-2 ring-sidebar',
-                      hasImportantUnread ? 'bg-amber-500' : 'bg-develop-blue'
+                      "shrink-0 inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-[10px] font-semibold leading-none group-data-[collapsible=icon]:hidden",
+                      hasImportantUnread
+                        ? "bg-amber-500 text-white"
+                        : "bg-develop-blue text-white",
                     )}
-                  />
-                )}
-              </span>
-              {/* 应用名与未读徽章必须是兄弟节点: 放在同一个 span 里时,
-                  span 没有 min-w-0/truncate 而按钮又是 overflow-visible,
-                  长名字(zh-CN)会把徽章一起顶出可视区域。 */}
-              <span className="min-w-0 flex-1 truncate font-semibold">{t('app.name')}</span>
-              {announcementTotalUnread > 0 && (
-                <span
-                  className={cn(
-                    'shrink-0 inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-[10px] font-semibold leading-none group-data-[collapsible=icon]:hidden',
-                    hasImportantUnread
-                      ? 'bg-amber-500 text-white'
-                      : 'bg-develop-blue text-white'
-                  )}
-                >
-                  {announcementTotalUnread > 99 ? '99+' : announcementTotalUnread}
-                </span>
-              )}
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarHeader>
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupLabel className="group-data-[collapsible=icon]:pointer-events-none">{t('nav.groupModules')}</SidebarGroupLabel>
-          {isMobile || state !== 'collapsed' ? (
-            <SidebarMenu className="grid grid-cols-2 gap-1 px-2">
-              {NAV_ITEMS.map(({ href, Icon, label }) => {
-                const fullHref = `/${locale}${href}`
-                const isActive = pathname.startsWith(fullHref)
-                const labelText = t(label)
-                return (
-                  <SidebarMenuItem key={href} className="list-none">
-                    <SidebarMenuButton
-                      isActive={isActive}
-                      tooltip={labelText}
-                      render={<NavLink href={fullHref} loadingLabel={labelText} />}
-                      onClick={() => {
-                        if (isMobile) setOpenMobile(false)
-                      }}
-                      className="h-auto min-h-14 flex-col items-center justify-center gap-1 px-1.5 py-2 text-[11px] leading-tight"
-                    >
-                      <Icon className="size-4 shrink-0" />
-                      <span className="w-full truncate text-center">{labelText}</span>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                )
-              })}
-            </SidebarMenu>
-          ) : (
-            <SidebarMenu>
-              {NAV_ITEMS.map(({ href, Icon, label }) => {
-                const fullHref = `/${locale}${href}`
-                const isActive = pathname.startsWith(fullHref)
-                const labelText = t(label)
-                return (
-                  <SidebarMenuItem key={href}>
-                    <SidebarMenuButton
-                      isActive={isActive}
-                      tooltip={labelText}
-                      render={<NavLink href={fullHref} loadingLabel={labelText} />}
-                      onClick={() => {
-                        if (isMobile) setOpenMobile(false)
-                      }}
-                    >
-                      <Icon />
-                      <span>{labelText}</span>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                )
-              })}
-            </SidebarMenu>
-          )}
-        </SidebarGroup>
-        {/* Wiki */}
-        <SidebarGroup>
-          <SidebarGroupLabel className="group-data-[collapsible=icon]:pointer-events-none">{t('nav.groupWiki')}</SidebarGroupLabel>
-          {isMobile || state !== 'collapsed' ? (
-            <SidebarMenu className="grid grid-cols-3 gap-1 px-2">
-              {WIKI_ITEMS.map(({ href, label, Icon }) => {
-                const fullHref = `/${locale}${href}`
-                const labelText = t(label)
-                return (
-                  <SidebarMenuItem key={href} className="list-none">
-                    <SidebarMenuButton
-                      isActive={pathname.startsWith(fullHref)}
-                      tooltip={labelText}
-                      render={<NavLink href={fullHref} loadingLabel={labelText} />}
-                      onClick={() => {
-                        if (isMobile) setOpenMobile(false)
-                      }}
-                      className="h-auto min-h-14 flex-col items-center justify-center gap-1 px-1 py-2 text-[11px] leading-tight"
-                    >
-                      <Icon className="size-4 shrink-0" />
-                      <span className="w-full truncate text-center">{labelText}</span>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                )
-              })}
-            </SidebarMenu>
-          ) : (
-            <SidebarMenu>
-              {WIKI_ITEMS.map(({ href, label, Icon }) => {
-                const fullHref = `/${locale}${href}`
-                const labelText = t(label)
-                return (
-                  <SidebarMenuItem key={href}>
-                    <SidebarMenuButton
-                      isActive={pathname.startsWith(fullHref)}
-                      tooltip={labelText}
-                      render={<NavLink href={fullHref} loadingLabel={labelText} />}
-                      onClick={() => {
-                        if (isMobile) setOpenMobile(false)
-                      }}
-                    >
-                      <Icon />
-                      <span>{labelText}</span>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                )
-              })}
-            </SidebarMenu>
-          )}
-        </SidebarGroup>
-        {/* Tools */}
-        <SidebarGroup>
-          <SidebarGroupLabel className="group-data-[collapsible=icon]:pointer-events-none">{t('nav.groupTools')}</SidebarGroupLabel>
-          <SidebarMenu>
-            {TOOL_ITEMS.map(({ href, label, Icon, external }) => {
-              const fullHref = external ? href : `/${locale}${href}`
-              const labelText = t(label)
-              return (
-                <SidebarMenuItem key={href}>
-                  <SidebarMenuButton
-                    isActive={!external && pathname.startsWith(fullHref)}
-                    tooltip={labelText}
-                    render={external
-                      ? <a href={href} target="_blank" rel="noopener noreferrer" />
-                      : <NavLink href={fullHref} loadingLabel={labelText} />
-                    }
-                    onClick={() => {
-                      if (isMobile) setOpenMobile(false)
-                    }}
                   >
-                    <Icon />
-                    <span>{labelText}</span>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              )
-            })}
-          </SidebarMenu>
-        </SidebarGroup>
-      </SidebarContent>
-      {/* Advertisement — desktop sidebar bottom; hidden in collapsed icon mode */}
-      <div className="hidden shrink-0 justify-center px-2 md:flex group-data-[collapsible=icon]:hidden">
-        <AdSlot variant="desktop" className="mb-2" />
-      </div>
-      <SidebarFooter>
-        <SidebarMenu>
-          {isUpdateAvailable && (
-            <SidebarMenuItem>
-              <div ref={refreshBtnRef}>
-                <SidebarMenuButton
-                  onClick={refreshPage}
-                  className="text-amber-600 hover:text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950"
-                >
-                  <RefreshCw className="size-4" />
-                  <span>{t('version.updatePrompt')}</span>
-                </SidebarMenuButton>
-              </div>
-              {mounted && state === 'collapsed' && createPortal(
-                <div
-                  style={{
-                    position: 'fixed',
-                    top: popupPos.top,
-                    left: popupPos.left,
-                    transform: 'translateY(-50%)',
-                    transition: 'top 0.3s ease, left 0.3s ease',
-                    zIndex: 9999,
-                  }}
-                  className="bg-amber-500 text-white px-3 py-1.5 rounded-md text-sm font-medium shadow-[0_0_18px_rgba(245,158,11,0.5)] transition-transform hover:scale-105 whitespace-nowrap"
-                >
-                  {/* Arrow pointing left toward the button */}
-                  <div className="absolute left-[-6px] top-1/2 -translate-y-1/2 w-0 h-0 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent border-r-[6px] border-r-amber-500" />
-                  {t('version.updatePrompt')}
-                </div>,
-                document.body
-              )}
-            </SidebarMenuItem>
-          )}
-          <SidebarMenuItem>
-            <LanguageSwitcher />
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              render={<NavLink href={`/${locale}/update`} loadingLabel={t('nav.update')} />}
-              tooltip={t('nav.update')}
-              onClick={() => { if (isMobile) setOpenMobile(false) }}
-            >
-              <Download />
-              {versionStr ? (
-                <span className="text-[11px] leading-tight">
-                  <span>{t('version.compatibleVersion')}: {versionMajorMinor}</span>
-                  <br />
-                  <span className="text-muted-foreground">
-                    {versionBuildTimeText} | {versionStr}
+                    {announcementTotalUnread > 99
+                      ? "99+"
+                      : announcementTotalUnread}
                   </span>
-                </span>
-              ) : (
-                <span>{t('nav.update')}</span>
-              )}
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              render={<NavLink href={`/${locale}/settings`} loadingLabel={t('nav.settings')} />}
-              onClick={() => { if (isMobile) setOpenMobile(false) }}
-            >
-              <Settings />
-              <span>{t('nav.settings')}</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              render={<NavLink href={`/${locale}/about`} loadingLabel={t('nav.about')} />}
-              onClick={() => { if (isMobile) setOpenMobile(false) }}
-            >
-              <Info />
-              <span>{t('nav.about')}</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          {!mounted ? null : !FEATURES.auth ? (
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                render={<NavLink href={`/${locale}/login`} loadingLabel={t('nav.login')} />}
-                tooltip={t('nav.login')}
-                onClick={() => { if (isMobile) setOpenMobile(false) }}
-              >
-                <LogIn className="size-4" />
-                <span>{t('nav.login')}</span>
+                )}
               </SidebarMenuButton>
             </SidebarMenuItem>
-          ) : accessToken ? (
-            <>
+          </SidebarMenu>
+        </SidebarHeader>
+        {/*
+        导航区与广告共用高度预算：wrapper 以自身内容高度参与收缩分配
+        （flex-basis auto 而非 flex-1 的 basis 0），空间不足时二者按比例
+        让位 —— 广告高度为 min(380px, 32svh)，下限 160px，短屏时再缩，
+        剩余差值由导航区滚动吸收。
+        上下渐隐提示是滚动容器外的绝对定位覆盖层（滚动条被 no-scrollbar
+        隐藏，溢出只能靠它表达），不占布局、不随内容滚动。
+      */}
+        <div className="relative min-h-0 flex-[1_1_auto]">
+          <SidebarContent
+            ref={contentRef}
+            onScroll={handleScroll}
+            className="h-full"
+          >
+            <SidebarGroup>
+              <SidebarGroupLabel className="group-data-[collapsible=icon]:pointer-events-none">
+                {t("nav.groupModules")}
+              </SidebarGroupLabel>
+              {isMobile || state !== "collapsed" ? (
+                <SidebarMenu className="grid grid-cols-3 gap-1 px-2">
+                  {NAV_ITEMS.map(({ href, Icon, label }) => {
+                    const fullHref = `/${locale}${href}`;
+                    const isActive = pathname.startsWith(fullHref);
+                    const labelText = t(label);
+                    return (
+                      <SidebarMenuItem key={href} className="list-none">
+                        <SidebarMenuButton
+                          isActive={isActive}
+                          tooltip={labelText}
+                          render={
+                            <NavLink href={fullHref} loadingLabel={labelText} />
+                          }
+                          onClick={() => {
+                            if (isMobile) setOpenMobile(false);
+                          }}
+                          className="h-auto min-h-14 [@media(max-height:800px)]:min-h-12 [@media(max-height:800px)]:py-1.5 flex-col items-center justify-center gap-1 px-1 py-2 text-[11px] leading-tight"
+                        >
+                          <Icon className="size-4 shrink-0" />
+                          <span className="w-full truncate text-center">
+                            {labelText}
+                          </span>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              ) : (
+                <SidebarMenu>
+                  {NAV_ITEMS.map(({ href, Icon, label }) => {
+                    const fullHref = `/${locale}${href}`;
+                    const isActive = pathname.startsWith(fullHref);
+                    const labelText = t(label);
+                    return (
+                      <SidebarMenuItem key={href}>
+                        <SidebarMenuButton
+                          isActive={isActive}
+                          tooltip={labelText}
+                          render={
+                            <NavLink href={fullHref} loadingLabel={labelText} />
+                          }
+                          onClick={() => {
+                            if (isMobile) setOpenMobile(false);
+                          }}
+                        >
+                          <Icon />
+                          <span>{labelText}</span>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              )}
+            </SidebarGroup>
+            {/* Wiki */}
+            <SidebarGroup>
+              <SidebarGroupLabel className="group-data-[collapsible=icon]:pointer-events-none">
+                {t("nav.groupWiki")}
+              </SidebarGroupLabel>
+              {isMobile || state !== "collapsed" ? (
+                <SidebarMenu className="grid grid-cols-3 gap-1 px-2">
+                  {WIKI_ITEMS.map(({ href, label, Icon }) => {
+                    const fullHref = `/${locale}${href}`;
+                    const labelText = t(label);
+                    return (
+                      <SidebarMenuItem key={href} className="list-none">
+                        <SidebarMenuButton
+                          isActive={pathname.startsWith(fullHref)}
+                          tooltip={labelText}
+                          render={
+                            <NavLink href={fullHref} loadingLabel={labelText} />
+                          }
+                          onClick={() => {
+                            if (isMobile) setOpenMobile(false);
+                          }}
+                          className="h-auto min-h-14 [@media(max-height:800px)]:min-h-12 [@media(max-height:800px)]:py-1.5 flex-col items-center justify-center gap-1 px-1 py-2 text-[11px] leading-tight"
+                        >
+                          <Icon className="size-4 shrink-0" />
+                          <span className="w-full truncate text-center">
+                            {labelText}
+                          </span>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              ) : (
+                <SidebarMenu>
+                  {WIKI_ITEMS.map(({ href, label, Icon }) => {
+                    const fullHref = `/${locale}${href}`;
+                    const labelText = t(label);
+                    return (
+                      <SidebarMenuItem key={href}>
+                        <SidebarMenuButton
+                          isActive={pathname.startsWith(fullHref)}
+                          tooltip={labelText}
+                          render={
+                            <NavLink href={fullHref} loadingLabel={labelText} />
+                          }
+                          onClick={() => {
+                            if (isMobile) setOpenMobile(false);
+                          }}
+                        >
+                          <Icon />
+                          <span>{labelText}</span>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              )}
+            </SidebarGroup>
+            {/* Tools */}
+            <SidebarGroup>
+              <SidebarGroupLabel className="group-data-[collapsible=icon]:pointer-events-none">
+                {t("nav.groupTools")}
+              </SidebarGroupLabel>
+              <SidebarMenu>
+                {TOOL_ITEMS.map(({ href, label, Icon, external }) => {
+                  const fullHref = external ? href : `/${locale}${href}`;
+                  const labelText = t(label);
+                  return (
+                    <SidebarMenuItem key={href}>
+                      <SidebarMenuButton
+                        isActive={!external && pathname.startsWith(fullHref)}
+                        tooltip={labelText}
+                        render={
+                          external ? (
+                            <a
+                              href={href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            />
+                          ) : (
+                            <NavLink href={fullHref} loadingLabel={labelText} />
+                          )
+                        }
+                        onClick={() => {
+                          if (isMobile) setOpenMobile(false);
+                        }}
+                      >
+                        <Icon />
+                        <span>{labelText}</span>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </SidebarGroup>
+          </SidebarContent>
+          {canScrollUp && (
+            <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-5 bg-gradient-to-b from-sidebar to-transparent" />
+          )}
+          {canScrollDown && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-5 bg-gradient-to-t from-sidebar to-transparent" />
+          )}
+        </div>
+        {/* Advertisement — desktop sidebar bottom; hidden in collapsed icon mode.
+          高度为 min(380px, 32svh)、下限 160px：短屏仍展示但为导航让位，
+          宽度由 AdSlot 按 280:380 等比跟随。 */}
+        <div className="hidden h-[min(380px,32svh)] min-h-40 shrink justify-center px-2 mb-2 md:flex group-data-[collapsible=icon]:hidden">
+          <AdSlot variant="desktop" />
+        </div>
+        <SidebarFooter>
+          <SidebarMenu>
+            {isUpdateAvailable && (
+              <SidebarMenuItem>
+                <div ref={refreshBtnRef}>
+                  <SidebarMenuButton
+                    onClick={refreshPage}
+                    className="text-amber-600 hover:text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950"
+                  >
+                    <RefreshCw className="size-4" />
+                    <span>{t("version.updatePrompt")}</span>
+                  </SidebarMenuButton>
+                </div>
+                {mounted &&
+                  state === "collapsed" &&
+                  createPortal(
+                    <div
+                      style={{
+                        position: "fixed",
+                        top: popupPos.top,
+                        left: popupPos.left,
+                        transform: "translateY(-50%)",
+                        transition: "top 0.3s ease, left 0.3s ease",
+                        zIndex: 9999,
+                      }}
+                      className="bg-amber-500 text-white px-3 py-1.5 rounded-md text-sm font-medium shadow-[0_0_18px_rgba(245,158,11,0.5)] transition-transform hover:scale-105 whitespace-nowrap"
+                    >
+                      {/* Arrow pointing left toward the button */}
+                      <div className="absolute left-[-6px] top-1/2 -translate-y-1/2 w-0 h-0 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent border-r-[6px] border-r-amber-500" />
+                      {t("version.updatePrompt")}
+                    </div>,
+                    document.body,
+                  )}
+              </SidebarMenuItem>
+            )}
+            <SidebarMenuItem>
+              <LanguageSwitcher />
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                render={
+                  <NavLink
+                    href={`/${locale}/update`}
+                    loadingLabel={t("nav.update")}
+                  />
+                }
+                tooltip={t("nav.update")}
+                onClick={() => {
+                  if (isMobile) setOpenMobile(false);
+                }}
+              >
+                <Download />
+                {versionStr ? (
+                  <span className="text-[11px] leading-tight">
+                    <span>
+                      {t("version.compatibleVersion")}: {versionMajorMinor}
+                    </span>
+                    <br />
+                    <span className="text-muted-foreground">
+                      {versionBuildTimeText} | {versionStr}
+                    </span>
+                  </span>
+                ) : (
+                  <span>{t("nav.update")}</span>
+                )}
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                render={
+                  <NavLink
+                    href={`/${locale}/settings`}
+                    loadingLabel={t("nav.settings")}
+                  />
+                }
+                onClick={() => {
+                  if (isMobile) setOpenMobile(false);
+                }}
+              >
+                <Settings />
+                <span>{t("nav.settings")}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                render={
+                  <NavLink
+                    href={`/${locale}/about`}
+                    loadingLabel={t("nav.about")}
+                  />
+                }
+                onClick={() => {
+                  if (isMobile) setOpenMobile(false);
+                }}
+              >
+                <Info />
+                <span>{t("nav.about")}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            {!mounted ? null : !FEATURES.auth ? (
               <SidebarMenuItem>
                 <SidebarMenuButton
-                  render={<NavLink href={`/${locale}/account`} loadingLabel={username || t('account.title')} />}
-                  tooltip={t('account.title')}
-                  onClick={() => { if (isMobile) setOpenMobile(false) }}
+                  render={
+                    <NavLink
+                      href={`/${locale}/login`}
+                      loadingLabel={t("nav.login")}
+                    />
+                  }
+                  tooltip={t("nav.login")}
+                  onClick={() => {
+                    if (isMobile) setOpenMobile(false);
+                  }}
                 >
-                  <CircleUser className="size-4" />
-                  <span>{username || t('account.title')}</span>
+                  <LogIn className="size-4" />
+                  <span>{t("nav.login")}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
-            </>
-          ) : sessionExpired ? (
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                render={<NavLink href={`/${locale}/login?expired=1`} loadingLabel={t('account.sessionExpired')} />}
-                tooltip={t('account.sessionExpired')}
-                className="text-amber-600 hover:text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950"
-                onClick={() => { if (isMobile) setOpenMobile(false) }}
-              >
-                <AlertTriangle className="size-4" />
-                <span>{t('account.sessionExpired')}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ) : (
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                render={<NavLink href={`/${locale}/login`} loadingLabel={t('nav.login')} />}
-                tooltip={t('nav.login')}
-                onClick={() => { if (isMobile) setOpenMobile(false) }}
-              >
-                <LogIn className="size-4" />
-                <span>{t('nav.login')}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          )}
-        </SidebarMenu>
-      </SidebarFooter>
+            ) : accessToken ? (
+              <>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    render={
+                      <NavLink
+                        href={`/${locale}/account`}
+                        loadingLabel={username || t("account.title")}
+                      />
+                    }
+                    tooltip={t("account.title")}
+                    onClick={() => {
+                      if (isMobile) setOpenMobile(false);
+                    }}
+                  >
+                    <CircleUser className="size-4" />
+                    <span>{username || t("account.title")}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </>
+            ) : sessionExpired ? (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={
+                    <NavLink
+                      href={`/${locale}/login?expired=1`}
+                      loadingLabel={t("account.sessionExpired")}
+                    />
+                  }
+                  tooltip={t("account.sessionExpired")}
+                  className="text-amber-600 hover:text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950"
+                  onClick={() => {
+                    if (isMobile) setOpenMobile(false);
+                  }}
+                >
+                  <AlertTriangle className="size-4" />
+                  <span>{t("account.sessionExpired")}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ) : (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={
+                    <NavLink
+                      href={`/${locale}/login`}
+                      loadingLabel={t("nav.login")}
+                    />
+                  }
+                  tooltip={t("nav.login")}
+                  onClick={() => {
+                    if (isMobile) setOpenMobile(false);
+                  }}
+                >
+                  <LogIn className="size-4" />
+                  <span>{t("nav.login")}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )}
+          </SidebarMenu>
+        </SidebarFooter>
         {forceUpgrade && <ForceUpgradeDialog />}
       </Sidebar>
     </TooltipProvider>
-  )
+  );
 }

--- a/src/components/shared/ad-slot.test.tsx
+++ b/src/components/shared/ad-slot.test.tsx
@@ -39,7 +39,7 @@ it('renders nothing when no ad is active (no placeholder)', () => {
   expect(container.childElementCount).toBe(0)
 })
 
-it('renders the desktop image sized 280x380 with a direct target link', () => {
+it('renders the desktop image with fluid 280:380 sizing and a direct target link', () => {
   useAdStore.setState({ currentAd: AD })
   const { container } = render(<AdSlot variant="desktop" />)
   const link = screen.getByRole('link')
@@ -48,8 +48,9 @@ it('renders the desktop image sized 280x380 with a direct target link', () => {
   const img = container.querySelector('img')
   expect(img?.getAttribute('src')).toBe(AD.desktopImageUrl)
   expect(img?.getAttribute('alt')).toBe('campaign')
-  expect(link.className).toContain('w-[280px]')
-  expect(link.className).toContain('h-[380px]')
+  expect(link.className).toContain('aspect-[280/380]')
+  expect(link.className).toContain('h-full')
+  expect(link.className).toContain('w-auto')
 })
 
 it('reports the click via sendBeacon without blocking the link', () => {

--- a/src/components/shared/ad-slot.tsx
+++ b/src/components/shared/ad-slot.tsx
@@ -14,9 +14,13 @@ export interface AdSlotProps {
   className?: string
 }
 
-/** 桌面侧边栏位 280x380（竖版）；移动端顶部 banner 320x100（横版）。 */
+/**
+ * 桌面侧边栏位 280x380（竖版）：高度由父容器决定（380px 起、可在空间不足时
+ * 收缩，见 app-sidebar 的挂载容器），宽度按素材比例 280:380 等比跟随，
+ * 素材完整展示不裁切；移动端顶部 banner 320x100（横版）为固定尺寸。
+ */
 const VARIANT_SIZE_CLASS: Record<AdSlotVariant, string> = {
-  desktop: 'h-[380px] w-[280px]',
+  desktop: 'h-full w-auto aspect-[280/380]',
   mobile: 'h-[100px] w-[320px]',
 }
 

--- a/src/hooks/use-sidebar-scroll-state.test.tsx
+++ b/src/hooks/use-sidebar-scroll-state.test.tsx
@@ -8,12 +8,15 @@ import { useSidebarScrollState } from './use-sidebar-scroll-state'
 type ScrollMetrics = { scrollTop: number; clientHeight: number; scrollHeight: number }
 
 let resizeCallback: ResizeObserverCallback | null = null
+const observedTargets: unknown[] = []
 
 class MockResizeObserver {
   constructor(callback: ResizeObserverCallback) {
     resizeCallback = callback
   }
-  observe = vi.fn()
+  observe = vi.fn((target: Element) => {
+    observedTargets.push(target)
+  })
   unobserve = vi.fn()
   disconnect = vi.fn()
 }
@@ -31,12 +34,15 @@ function emitResize() {
 }
 
 function Harness() {
-  const { canScrollUp, canScrollDown, contentRef, handleScroll } = useSidebarScrollState()
+  const { canScrollUp, canScrollDown, contentRef, contentInnerRef, handleScroll } =
+    useSidebarScrollState()
   return (
     <div>
       <span data-testid="up">{String(canScrollUp)}</span>
       <span data-testid="down">{String(canScrollDown)}</span>
-      <div ref={contentRef} onScroll={handleScroll} data-testid="scroller" />
+      <div ref={contentRef} onScroll={handleScroll} data-testid="scroller">
+        <div ref={contentInnerRef} data-testid="content" />
+      </div>
     </div>
   )
 }
@@ -44,6 +50,7 @@ function Harness() {
 beforeEach(() => {
   vi.stubGlobal('ResizeObserver', MockResizeObserver)
   resizeCallback = null
+  observedTargets.length = 0
 })
 
 afterEach(() => {
@@ -67,6 +74,12 @@ it('reports content below on mount via ResizeObserver', () => {
   emitResize()
   expect(screen.getByTestId('up').textContent).toBe('false')
   expect(screen.getByTestId('down').textContent).toBe('true')
+})
+
+it('observes both the scroll container and the content layer', () => {
+  render(<Harness />)
+  expect(observedTargets).toContain(screen.getByTestId('scroller'))
+  expect(observedTargets).toContain(screen.getByTestId('content'))
 })
 
 it('tracks both directions across scroll events', () => {

--- a/src/hooks/use-sidebar-scroll-state.test.tsx
+++ b/src/hooks/use-sidebar-scroll-state.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import { useSidebarScrollState } from './use-sidebar-scroll-state'
+
+type ScrollMetrics = { scrollTop: number; clientHeight: number; scrollHeight: number }
+
+let resizeCallback: ResizeObserverCallback | null = null
+
+class MockResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = callback
+  }
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+
+function setScrollMetrics(el: HTMLElement, metrics: ScrollMetrics) {
+  Object.defineProperty(el, 'scrollTop', { value: metrics.scrollTop, configurable: true })
+  Object.defineProperty(el, 'clientHeight', { value: metrics.clientHeight, configurable: true })
+  Object.defineProperty(el, 'scrollHeight', { value: metrics.scrollHeight, configurable: true })
+}
+
+function emitResize() {
+  act(() => {
+    resizeCallback?.([], {} as ResizeObserver)
+  })
+}
+
+function Harness() {
+  const { canScrollUp, canScrollDown, contentRef, handleScroll } = useSidebarScrollState()
+  return (
+    <div>
+      <span data-testid="up">{String(canScrollUp)}</span>
+      <span data-testid="down">{String(canScrollDown)}</span>
+      <div ref={contentRef} onScroll={handleScroll} data-testid="scroller" />
+    </div>
+  )
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', MockResizeObserver)
+  resizeCallback = null
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+it('reports no scrolling when content fits', () => {
+  render(<Harness />)
+  const scroller = screen.getByTestId('scroller')
+  setScrollMetrics(scroller, { scrollTop: 0, clientHeight: 472, scrollHeight: 472 })
+  emitResize()
+  expect(screen.getByTestId('up').textContent).toBe('false')
+  expect(screen.getByTestId('down').textContent).toBe('false')
+})
+
+it('reports content below on mount via ResizeObserver', () => {
+  render(<Harness />)
+  const scroller = screen.getByTestId('scroller')
+  setScrollMetrics(scroller, { scrollTop: 0, clientHeight: 322, scrollHeight: 472 })
+  emitResize()
+  expect(screen.getByTestId('up').textContent).toBe('false')
+  expect(screen.getByTestId('down').textContent).toBe('true')
+})
+
+it('tracks both directions across scroll events', () => {
+  render(<Harness />)
+  const scroller = screen.getByTestId('scroller')
+  setScrollMetrics(scroller, { scrollTop: 0, clientHeight: 322, scrollHeight: 472 })
+  emitResize()
+
+  setScrollMetrics(scroller, { scrollTop: 80, clientHeight: 322, scrollHeight: 472 })
+  act(() => {
+    scroller.dispatchEvent(new Event('scroll'))
+  })
+  expect(screen.getByTestId('up').textContent).toBe('true')
+  expect(screen.getByTestId('down').textContent).toBe('true')
+
+  setScrollMetrics(scroller, { scrollTop: 150, clientHeight: 322, scrollHeight: 472 })
+  act(() => {
+    scroller.dispatchEvent(new Event('scroll'))
+  })
+  expect(screen.getByTestId('up').textContent).toBe('true')
+  expect(screen.getByTestId('down').textContent).toBe('false')
+})

--- a/src/hooks/use-sidebar-scroll-state.ts
+++ b/src/hooks/use-sidebar-scroll-state.ts
@@ -9,6 +9,8 @@ export interface SidebarScrollState {
   canScrollDown: boolean
   /** 绑定到滚动容器的 ref。 */
   contentRef: RefObject<HTMLDivElement | null>
+  /** 绑定到滚动内容层的 ref（scrollHeight 随子项变化）。 */
+  contentInnerRef: RefObject<HTMLDivElement | null>
   /** 绑定到滚动容器 onScroll。 */
   handleScroll: () => void
 }
@@ -17,11 +19,13 @@ export interface SidebarScrollState {
  * 侧边栏导航区的滚动状态。滚动条被 no-scrollbar 隐藏，溢出只能靠
  * 上下渐隐提示表达；该 hook 跟踪两个方向是否仍有剩余内容。
  *
- * 除了 scroll 事件外还挂 ResizeObserver：广告高度自适应、页脚增删项
- * 都会改变滚动容器的可视高度，这些变化不产生 scroll 事件。
+ * 同时 observe 容器与内容层：广告/页脚改变的是容器可视高度；子项增减、
+ * 收起展开切换结构只改 scrollHeight，容器尺寸不变时 ResizeObserver 不会
+ * 对容器触发，必须听内容层。
  */
 export function useSidebarScrollState(): SidebarScrollState {
   const contentRef = useRef<HTMLDivElement>(null)
+  const contentInnerRef = useRef<HTMLDivElement>(null)
   const [canScrollUp, setCanScrollUp] = useState(false)
   const [canScrollDown, setCanScrollDown] = useState(false)
 
@@ -34,14 +38,22 @@ export function useSidebarScrollState(): SidebarScrollState {
 
   useEffect(() => {
     const el = contentRef.current
+    const inner = contentInnerRef.current
     if (!el) return
     sync()
     const observer = new ResizeObserver(sync)
     observer.observe(el)
+    if (inner) observer.observe(inner)
     return () => observer.disconnect()
   }, [sync])
 
-  return { canScrollUp, canScrollDown, contentRef, handleScroll: sync }
+  return {
+    canScrollUp,
+    canScrollDown,
+    contentRef,
+    contentInnerRef,
+    handleScroll: sync,
+  }
 }
 
 export default useSidebarScrollState

--- a/src/hooks/use-sidebar-scroll-state.ts
+++ b/src/hooks/use-sidebar-scroll-state.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+
+export interface SidebarScrollState {
+  /** 内容上方还有未展示内容（应显示顶部渐隐提示）。 */
+  canScrollUp: boolean
+  /** 内容下方还有未展示内容（应显示底部渐隐提示）。 */
+  canScrollDown: boolean
+  /** 绑定到滚动容器的 ref。 */
+  contentRef: RefObject<HTMLDivElement | null>
+  /** 绑定到滚动容器 onScroll。 */
+  handleScroll: () => void
+}
+
+/**
+ * 侧边栏导航区的滚动状态。滚动条被 no-scrollbar 隐藏，溢出只能靠
+ * 上下渐隐提示表达；该 hook 跟踪两个方向是否仍有剩余内容。
+ *
+ * 除了 scroll 事件外还挂 ResizeObserver：广告高度自适应、页脚增删项
+ * 都会改变滚动容器的可视高度，这些变化不产生 scroll 事件。
+ */
+export function useSidebarScrollState(): SidebarScrollState {
+  const contentRef = useRef<HTMLDivElement>(null)
+  const [canScrollUp, setCanScrollUp] = useState(false)
+  const [canScrollDown, setCanScrollDown] = useState(false)
+
+  const sync = useCallback(() => {
+    const el = contentRef.current
+    if (!el) return
+    setCanScrollUp(el.scrollTop > 0)
+    setCanScrollDown(el.scrollTop + el.clientHeight < el.scrollHeight - 1)
+  }, [])
+
+  useEffect(() => {
+    const el = contentRef.current
+    if (!el) return
+    sync()
+    const observer = new ResizeObserver(sync)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [sync])
+
+  return { canScrollUp, canScrollDown, contentRef, handleScroll: sync }
+}
+
+export default useSidebarScrollState


### PR DESCRIPTION
## Sourcery 总结

优化侧边栏布局和空间适配，减少广告及长文本对导航内容的遮挡。

新功能：
- 将侧边栏导航改为更紧凑的三列布局，并根据屏幕高度自适应项目尺寸。
- 为导航内容增加可滚动区域及上下渐隐提示，提升短屏和空间不足时的可用性。
- 使桌面广告按容器高度和素材比例自适应缩放，避免大幅遮挡导航内容。

错误修复：
- 修复长本地化应用名称挤出未读徽章的问题。

改进：
- 重新分配侧边栏导航、广告和页脚的高度预算，使有限空间下导航能够滚动并保留广告展示。

测试：
- 新增侧边栏滚动状态在内容适配、滚动和尺寸变化场景下的测试。
- 更新桌面广告组件测试以验证流式尺寸行为。

杂项：
- 统一侧边栏组件代码格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化侧边栏的空间适配和导航可用性，减少广告及长文本对内容的遮挡。

New Features:
- 优化展开和移动端侧边栏导航为更紧凑的三列布局，并根据屏幕高度调整项目尺寸。
- 为侧边栏导航增加可滚动区域及上下渐隐提示，以适配有限空间。

Bug Fixes:
- 修复长本地化应用名称导致未读数量徽章被挤出的问题。
- 调整桌面广告尺寸以减少其对侧边栏导航内容的遮挡。

Enhancements:
- 重新平衡侧边栏导航、广告和页脚的空间分配，使导航在短屏幕上可滚动并保留广告展示。

Tests:
- 新增侧边栏滚动状态在内容溢出、滚动和尺寸变化场景下的测试。
- 更新桌面广告测试以验证流式比例缩放。

Chores:
- 统一侧边栏组件代码格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化侧边栏的空间适配和导航可用性，减少广告及长文本对内容的遮挡。

New Features:
- 优化展开和移动端侧边栏导航为更紧凑的三列布局，并根据屏幕高度调整项目尺寸。
- 为侧边栏导航增加可滚动区域及上下渐隐提示，以适配有限空间。

Bug Fixes:
- 修复长本地化应用名称导致未读数量徽章被挤出的问题。
- 调整桌面广告尺寸以减少其对侧边栏导航内容的遮挡。

Enhancements:
- 重新平衡侧边栏导航、广告和页脚的空间分配，使导航在短屏幕上可滚动并保留广告展示。

Tests:
- 新增侧边栏滚动状态在内容溢出、滚动和尺寸变化场景下的测试。
- 更新桌面广告测试以验证流式比例缩放。

Chores:
- 统一侧边栏组件代码格式。

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 侧栏新增内容滚动状态提示，可显示上方或下方仍有内容。
  - 侧栏广告区域支持随可用空间收缩，并根据屏幕高度自适应。
  - 模块导航调整为三列网格布局，较矮屏幕下按钮尺寸更合适。
- **样式优化**
  - 桌面端广告宽度改为按 280:380 比例自适应，高度跟随容器；移动端尺寸保持不变。
  - 侧栏导航、Wiki、工具及页脚链接的展示样式统一。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->