### PR TITLE
修复移动端banner的一些适配问题

### DIFF
--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -38,17 +38,17 @@ export default function HomePage() {
         description={t('meta.homeDescription')}
         url={`${siteUrl}${pathname}`}
       />
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+      <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
         {/* Top bar */}
-        <div className="flex items-center gap-3 px-4 py-2 border-b border-border">
+        <div className="sticky top-0 z-30 flex items-center gap-3 border-b border-border bg-background/95 px-4 py-2 backdrop-blur">
           <SidebarTrigger />
           <h1 className="text-base font-semibold tracking-tight">
             {t('app.name')}
           </h1>
         </div>
 
-      {/* Scrollable content */}
-      <div className="flex-1 overflow-auto">
+      {/* Scrollable content — mobile 由布局滚动壳承载 */}
+      <div className="md:flex-1 md:overflow-auto">
         <div className="mx-auto max-w-5xl px-6 py-8 space-y-8">
           <GreetingSection greetingKey={greetingKey} />
           <RealTimeClock />

--- a/src/app/[locale]/(legal)/privacy/page.tsx
+++ b/src/app/[locale]/(legal)/privacy/page.tsx
@@ -46,14 +46,14 @@ export default async function PrivacyPage({
   const t = await getTranslations({ locale })
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-border shrink-0">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+      <div className="flex items-center gap-3 border-b border-border px-4 py-2 shrink-0">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">
           {t('legal.privacyTitle')}
         </h1>
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div className="md:flex-1 md:overflow-y-auto">
         <article className="max-w-3xl mx-auto px-4 py-8">
           <ReactMarkdown components={markdownComponents}>
             {t('legal.privacyContent')}

--- a/src/app/[locale]/(legal)/terms/page.tsx
+++ b/src/app/[locale]/(legal)/terms/page.tsx
@@ -46,14 +46,14 @@ export default async function TermsPage({
   const t = await getTranslations({ locale })
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-border shrink-0">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+      <div className="flex items-center gap-3 border-b border-border px-4 py-2 shrink-0">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">
           {t('legal.termsTitle')}
         </h1>
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div className="md:flex-1 md:overflow-y-auto">
         <article className="max-w-3xl mx-auto px-4 py-8">
           <ReactMarkdown components={markdownComponents}>
             {t('legal.termsContent')}

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -53,7 +53,7 @@ export default function AboutPage() {
   const t = useTranslations()
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
       {/* Top bar */}
       <div className="flex items-center gap-3 px-4 py-2 border-b border-border">
         <SidebarTrigger />
@@ -63,7 +63,7 @@ export default function AboutPage() {
       </div>
 
       {/* Main content */}
-      <div className="flex-1 overflow-auto p-4 md:p-8">
+      <div className="p-4 md:flex-1 md:overflow-auto md:p-8">
         <div className="max-w-3xl mx-auto">
           {/* Hero: left-right layout (stacked on mobile) */}
           <div className="flex flex-col md:flex-row items-center md:items-start gap-6 md:gap-8 mb-10">

--- a/src/app/[locale]/account/page.tsx
+++ b/src/app/[locale]/account/page.tsx
@@ -756,9 +756,9 @@ export default function AccountPage() {
   // preventing server-vs-client HTML mismatch from Zustand persist rehydration.
   if (!mounted) {
     return (
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-        <div className="flex items-center gap-3 px-4 py-2 border-b border-border"><SidebarTrigger /><h1 className="text-base font-semibold tracking-tight">{t('account.title')}</h1></div>
-        <div className="flex-1 flex items-center justify-center p-6">
+      <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+        <div className="flex items-center gap-3 border-b border-border px-4 py-2"><SidebarTrigger /><h1 className="text-base font-semibold tracking-tight">{t('account.title')}</h1></div>
+        <div className="flex items-center justify-center p-6 md:min-h-0 md:flex-1">
           <Loader2 className="size-6 animate-spin text-muted-foreground" />
         </div>
       </div>
@@ -767,9 +767,9 @@ export default function AccountPage() {
 
   if (!accessToken) {
     return (
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-        <div className="flex items-center gap-3 px-4 py-2 border-b border-border"><SidebarTrigger /><h1 className="text-base font-semibold tracking-tight">{t('account.title')}</h1></div>
-        <div className="flex-1 flex items-center justify-center p-6">
+      <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+        <div className="flex items-center gap-3 border-b border-border px-4 py-2"><SidebarTrigger /><h1 className="text-base font-semibold tracking-tight">{t('account.title')}</h1></div>
+        <div className="flex items-center justify-center p-6 md:min-h-0 md:flex-1">
           <Card className="w-full max-w-sm"><CardContent className="py-8 text-center space-y-4">
             <AlertTriangle className="size-8 text-amber-500 mx-auto" />
             <p className="text-muted-foreground">{t('account.sessionExpired')}</p>
@@ -781,9 +781,9 @@ export default function AccountPage() {
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-border"><SidebarTrigger /><h1 className="text-base font-semibold tracking-tight">{t('account.title')}</h1></div>
-      <div className="flex-1 overflow-y-auto p-6 [scrollbar-gutter:stable]"><div className="max-w-2xl mx-auto space-y-6">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+      <div className="sticky top-0 z-30 flex items-center gap-3 border-b border-border bg-background/95 px-4 py-2 backdrop-blur"><SidebarTrigger /><h1 className="text-base font-semibold tracking-tight">{t('account.title')}</h1></div>
+      <div className="p-6 [scrollbar-gutter:stable] md:flex-1 md:overflow-y-auto"><div className="max-w-2xl mx-auto space-y-6">
 
         {/* ── Tab Navigation ── */}
         <div className="flex rounded-lg border border-border overflow-hidden">

--- a/src/app/[locale]/background-preview/page.tsx
+++ b/src/app/[locale]/background-preview/page.tsx
@@ -18,7 +18,7 @@ export default function BackgroundPreviewPage() {
 
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 px-4 py-2 shadow-[var(--shadow-border-b)]">
         <SidebarTrigger />
         <h1 className="min-w-0 flex-1 truncate text-base font-semibold tracking-tight">{t('nav.backgroundPreview')}</h1>
@@ -47,7 +47,7 @@ export default function BackgroundPreviewPage() {
         </Tooltip>
       </header>
 
-      <main className="relative min-h-0 flex-1 overflow-hidden">
+      <main className="relative min-h-[50vh] md:min-h-0 md:flex-1 md:overflow-hidden">
         <button
           type="button"
           className="absolute inset-0 size-full cursor-pointer select-none rounded-none bg-transparent text-sm text-muted-foreground transition-colors hover:bg-transparent hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:outline-none"

--- a/src/app/[locale]/essence-planner/page.tsx
+++ b/src/app/[locale]/essence-planner/page.tsx
@@ -439,7 +439,7 @@ export default function EssencePlannerPage() {
         description={t('meta.essencePlannerDescription')}
         url={`${siteUrl}${pathname}`}
       />
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+      <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
         {/* Top bar */}
         <div className="flex items-center gap-3 px-4 py-2 border-b border-border">
           <SidebarTrigger />
@@ -476,8 +476,9 @@ export default function EssencePlannerPage() {
         </div>
       </div>
 
-      {/* Mobile layout: segmented control + single panel + bottom bar */}
-      <div className="flex md:hidden flex-col flex-1 overflow-hidden">
+      {/* Mobile layout: segmented control + single panel + bottom bar.
+          内容高度由外层滚动壳承载（广告随内容滚出），底栏 sticky 贴底。 */}
+      <div className="flex md:hidden flex-col">
         {/* Segmented control */}
         <div className="flex mx-4 mt-3 rounded-lg bg-muted p-0.5">
           <Button
@@ -508,8 +509,8 @@ export default function EssencePlannerPage() {
           </Button>
         </div>
 
-        {/* Content area — min-h-0 prevents flex overflow if layout chain breaks */}
-        <div className="flex-1 min-h-0 overflow-y-auto">
+        {/* Content area — mobile 由布局滚动壳滚动，桌面双栏各自滚动 */}
+        <div className="pb-2">
           {mobileView === 'weapons' ? (
             <div className="p-3 pb-16">
               <WeaponGrid onViewAll={() => setViewAllOpen(true)} />
@@ -522,7 +523,7 @@ export default function EssencePlannerPage() {
         </div>
 
         {/* Bottom bar */}
-        <div className="relative safe-area-mb z-40 flex items-center justify-between px-4 py-2.5 shadow-[var(--shadow-border-inset-t)] bg-background">
+        <div className="sticky bottom-0 relative safe-area-mb z-40 flex items-center justify-between px-4 py-2.5 shadow-[var(--shadow-border-inset-t)] bg-background">
           <span className="text-sm text-muted-foreground">
             {t('essence.selectedCount', { count: selectedCount })}
           </span>

--- a/src/app/[locale]/essence-planner/page.tsx
+++ b/src/app/[locale]/essence-planner/page.tsx
@@ -477,10 +477,11 @@ export default function EssencePlannerPage() {
       </div>
 
       {/* Mobile layout: segmented control + single panel + bottom bar.
-          内容高度由外层滚动壳承载（广告随内容滚出），底栏 sticky 贴底。 */}
+          内容由布局滚动壳滚动；分段控件 sticky 钉在滚动壳顶部（原先靠
+          内部 overflow 区外的结构钉住，改外层滚动后必须用 sticky）。 */}
       <div className="flex md:hidden flex-col">
-        {/* Segmented control */}
-        <div className="flex mx-4 mt-3 rounded-lg bg-muted p-0.5">
+        {/* Segmented control — sticky 钉在滚动壳顶；z-40 盖过武器卡角标的 z-30 */}
+        <div className="sticky top-0 z-40 mx-4 mt-3 flex shrink-0 rounded-lg bg-muted p-0.5">
           <Button
             type="button"
             variant="ghost"
@@ -510,20 +511,22 @@ export default function EssencePlannerPage() {
         </div>
 
         {/* Content area — mobile 由布局滚动壳滚动，桌面双栏各自滚动 */}
-        <div className="pb-2">
+        <div className="pb-24">
           {mobileView === 'weapons' ? (
-            <div className="p-3 pb-16">
+            <div className="p-3">
               <WeaponGrid onViewAll={() => setViewAllOpen(true)} />
             </div>
           ) : (
-            <div className="p-4 pb-16">
+            <div className="p-4">
               {renderPlanList()}
             </div>
           )}
         </div>
 
-        {/* Bottom bar */}
-        <div className="sticky bottom-0 relative safe-area-mb z-40 flex items-center justify-between px-4 py-2.5 shadow-[var(--shadow-border-inset-t)] bg-background">
+        {/* Bottom bar — fixed so it stays reachable while the layout shell scrolls
+            the page content (sticky on a trailing flex child would only appear
+            after scrolling to the end). Parent is md:hidden, desktop unaffected. */}
+        <div className="fixed inset-x-0 bottom-0 safe-area-bottom-bar z-40 flex items-center justify-between bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
           <span className="text-sm text-muted-foreground">
             {t('essence.selectedCount', { count: selectedCount })}
           </span>

--- a/src/app/[locale]/forum/page.tsx
+++ b/src/app/[locale]/forum/page.tsx
@@ -21,7 +21,7 @@ export default function ForumPage() {
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
       {/* Top bar */}
       <div className="flex items-center gap-3 px-4 py-2 shadow-[var(--shadow-border-b)] shrink-0">
         <SidebarTrigger />
@@ -49,7 +49,7 @@ export default function ForumPage() {
       {/* Forum iframe */}
       <iframe
         src={FEATURES.forumUrl}
-        className="flex-1 w-full border-none"
+        className="min-h-[70vh] w-full border-none md:min-h-0 md:flex-1"
         title={t('nav.forum')}
         allow="clipboard-write"
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups"

--- a/src/app/[locale]/growth-planner/page.tsx
+++ b/src/app/[locale]/growth-planner/page.tsx
@@ -138,16 +138,17 @@ export default function GrowthPlannerPage() {
         {desktopView === 'summary' ? <GrowthSummary /> : <MaterialReversePanel />}
       </main>
       <GrowthFloatingPicker />
-      <div className="flex flex-col lg:hidden">
-        <div className="sticky top-0 z-30 mx-4 mt-3 flex shrink-0 rounded-lg bg-background/95 p-0.5 backdrop-blur">
+      {/* <lg：单栏。md–lg 时外层已 overflow-hidden，此容器自滚；<md 由布局滚动壳滚。 */}
+      <div className="flex flex-col md:min-h-0 md:flex-1 lg:hidden">
+        <div className="sticky top-0 z-40 mx-4 mt-3 flex shrink-0 rounded-lg bg-muted p-0.5">
           <Button type="button" variant="ghost" aria-pressed={mobileView === 'selection'} onClick={() => setMobileView('selection')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'selection' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('selectionTab')}</Button>
           <Button type="button" variant="ghost" aria-pressed={mobileView === 'summary'} onClick={() => setMobileView('summary')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'summary' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('summaryTab')}</Button>
           <Button type="button" variant="ghost" aria-pressed={mobileView === 'materials'} onClick={() => setMobileView('materials')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'materials' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('materialsTab')}</Button>
         </div>
-        <div className="pb-2">
+        <div className="pb-24 md:min-h-0 md:flex-1 md:overflow-y-auto">
           {mobileView === 'selection' ? <div className="flex flex-col p-3"><GrowthEntityPicker onEntityAdded={handleEntityAdded} /></div> : mobileView === 'materials' ? <div className="p-4"><MaterialReversePanel /></div> : <div className="p-4"><GrowthSummary /></div>}
         </div>
-        <div className="sticky bottom-0 safe-area-mb relative z-40 flex shrink-0 items-center justify-between bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
+        <div className="fixed inset-x-0 bottom-0 safe-area-bottom-bar z-40 flex shrink-0 items-center justify-between bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
           <span className="text-sm text-muted-foreground">{t('selectedCount', { count: configs.length })}</span>
           <Button type="button" variant={mobileView === 'selection' ? 'default' : 'outline'} size="sm" onClick={() => setMobileView(mobileView === 'selection' ? 'summary' : 'selection')} disabled={mobileView === 'selection' && configs.length === 0}>{mobileView === 'selection' ? t('viewSummary') : t('manageTargets')}</Button>
         </div>

--- a/src/app/[locale]/growth-planner/page.tsx
+++ b/src/app/[locale]/growth-planner/page.tsx
@@ -54,9 +54,9 @@ export default function GrowthPlannerPage() {
   // stuck on skeletons forever; offer an explicit retry instead.
   if (plannerError) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
         {renderHeader(true)}
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        <div className="p-4 md:min-h-0 md:flex-1 md:overflow-y-auto">
           <DataLoadError onRetry={retryPlannerData} />
         </div>
       </div>
@@ -69,7 +69,7 @@ export default function GrowthPlannerPage() {
   // sees raw ids like `chr_9000_endmin` and searches only match ids.
   if (!plannerData || !wikiTextReady) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
         {renderHeader(true)}
         <div className="h-[5.5rem] shrink-0 px-4 py-3 shadow-[var(--shadow-border-b)]">
           <div className="flex h-16 items-center gap-2">
@@ -78,7 +78,7 @@ export default function GrowthPlannerPage() {
             <Skeleton className="size-12 rounded-md" />
           </div>
         </div>
-        <div className="grid min-h-0 flex-1 gap-4 overflow-hidden p-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.48fr)]">
+        <div className="grid gap-4 p-4 md:min-h-0 md:flex-1 md:overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.48fr)]">
           <div className="flex min-h-0 flex-col gap-3">
             <Skeleton className="h-28 w-full rounded-xl" />
             <Skeleton className="min-h-0 w-full flex-1 rounded-xl" />
@@ -94,7 +94,7 @@ export default function GrowthPlannerPage() {
   const { wikiCharacters, wikiWeapons } = plannerData
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       {renderHeader(configs.length === 0)}
       <div data-growth-target-strip className="h-[5.5rem] shrink-0 overflow-x-auto px-4 py-3 shadow-[var(--shadow-border-b)]">
         <div className="flex h-16 min-w-max items-center gap-2">
@@ -138,16 +138,16 @@ export default function GrowthPlannerPage() {
         {desktopView === 'summary' ? <GrowthSummary /> : <MaterialReversePanel />}
       </main>
       <GrowthFloatingPicker />
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:hidden">
-        <div className="mx-4 mt-3 flex shrink-0 rounded-lg bg-muted p-0.5">
+      <div className="flex flex-col lg:hidden">
+        <div className="sticky top-0 z-30 mx-4 mt-3 flex shrink-0 rounded-lg bg-background/95 p-0.5 backdrop-blur">
           <Button type="button" variant="ghost" aria-pressed={mobileView === 'selection'} onClick={() => setMobileView('selection')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'selection' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('selectionTab')}</Button>
           <Button type="button" variant="ghost" aria-pressed={mobileView === 'summary'} onClick={() => setMobileView('summary')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'summary' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('summaryTab')}</Button>
           <Button type="button" variant="ghost" aria-pressed={mobileView === 'materials'} onClick={() => setMobileView('materials')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'materials' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('materialsTab')}</Button>
         </div>
-        <div className="min-h-0 flex-1 overflow-hidden">
-          {mobileView === 'selection' ? <div className="flex h-full min-h-0 flex-col p-3"><GrowthEntityPicker onEntityAdded={handleEntityAdded} /></div> : mobileView === 'materials' ? <div className="h-full overflow-y-auto p-4"><MaterialReversePanel /></div> : <div className="h-full overflow-y-auto p-4"><GrowthSummary /></div>}
+        <div className="pb-2">
+          {mobileView === 'selection' ? <div className="flex flex-col p-3"><GrowthEntityPicker onEntityAdded={handleEntityAdded} /></div> : mobileView === 'materials' ? <div className="p-4"><MaterialReversePanel /></div> : <div className="p-4"><GrowthSummary /></div>}
         </div>
-        <div className="safe-area-mb relative z-40 flex shrink-0 items-center justify-between bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
+        <div className="sticky bottom-0 safe-area-mb relative z-40 flex shrink-0 items-center justify-between bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
           <span className="text-sm text-muted-foreground">{t('selectedCount', { count: configs.length })}</span>
           <Button type="button" variant={mobileView === 'selection' ? 'default' : 'outline'} size="sm" onClick={() => setMobileView(mobileView === 'selection' ? 'summary' : 'selection')} disabled={mobileView === 'selection' && configs.length === 0}>{mobileView === 'selection' ? t('viewSummary') : t('manageTargets')}</Button>
         </div>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -118,12 +118,17 @@ export default async function LocaleLayout({
               {IS_DEV_BUILD ? <DevBuildNotice siteUrl={siteUrl} /> : null}
               {/* 紧急公告置于所有横幅最上方 —— 运营下发的最高优先级信息 */}
               <EmergencyNoticeBanner />
-              <MobileAdBanner />
               <HolidayBanner />
               <BirthdayBanner />
               <ImportantAnnouncementBanner />
               <ExtensionCssDetector />
-              {children}
+              {/* 内容滚动壳：移动端整页内容与顶部广告共用一个滚动上下文
+                  （广告随内容滚出视口）；桌面保持 overflow-hidden，各页
+                  自行用 flex-1 + 内部面板滚动（高度链规范见 AGENTS.md）。 */}
+              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto md:overflow-hidden">
+                <MobileAdBanner />
+                {children}
+              </div>
               <NavigationLoadingOverlay />
               <VersionWatermark />
             </main>

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -197,15 +197,15 @@ function LoginPageContent() {
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-border">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+      <div className="flex items-center gap-3 border-b border-border px-4 py-2">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">
           {isLogin ? t('nav.login') : t('nav.register')}
         </h1>
       </div>
-      <div className="flex-1 overflow-y-auto">
-        <div className="flex items-center justify-center min-h-full p-4">
+      <div className="md:flex-1 md:overflow-y-auto">
+        <div className="flex items-center justify-center min-h-[50vh] p-4 md:min-h-full">
           <div className="w-full max-w-sm py-8">
         <div className="mb-8 text-center">
           <h1 className="text-xl font-semibold tracking-[-0.48px] text-foreground">
@@ -626,7 +626,7 @@ function LoginUnavailableGuide() {
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
       <div className="flex items-center gap-3 px-4 py-2 border-b border-border">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">{t('auth.unavailableTitle')}</h1>

--- a/src/app/[locale]/oauth/authorize/page.tsx
+++ b/src/app/[locale]/oauth/authorize/page.tsx
@@ -58,8 +58,8 @@ export default function OAuthAuthorizePage() {
 
 function OAuthLoading() {
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-      <div className="flex-1 flex items-center justify-center">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+      <div className="flex items-center justify-center p-4 md:min-h-0 md:flex-1">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
       </div>
     </div>
@@ -170,8 +170,8 @@ function OAuthAuthorizeContent() {
   // ── Missing parameters ──────────────────────────────────
   if (missingParams) {
     return (
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-        <div className="flex-1 flex items-center justify-center p-4">
+      <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+        <div className="flex items-center justify-center p-4 md:min-h-0 md:flex-1">
           <div className="w-full max-w-sm text-center space-y-4">
             <ShieldAlert className="size-12 mx-auto text-destructive" />
             <h1 className="text-lg font-semibold">{t('oauth.invalidRequest')}</h1>
@@ -185,9 +185,9 @@ function OAuthAuthorizeContent() {
   // ── Login required ──────────────────────────────────────
   if (needsLogin) {
     return (
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-        <div className="flex-1 overflow-y-auto">
-          <div className="flex items-center justify-center min-h-full p-4">
+      <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+        <div className="md:flex-1 md:overflow-y-auto">
+          <div className="flex items-center justify-center min-h-[50vh] p-4 md:min-h-full">
             <div className="w-full max-w-sm py-8 space-y-6">
               <div className="text-center space-y-2">
                 <LogIn className="size-10 mx-auto text-muted-foreground" />
@@ -303,9 +303,9 @@ function OAuthAuthorizeContent() {
 
   // ── Consent screen ──────────────────────────────────────
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-      <div className="flex-1 overflow-y-auto">
-        <div className="flex items-center justify-center min-h-full p-4">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
+      <div className="md:flex-1 md:overflow-y-auto">
+        <div className="flex items-center justify-center min-h-[50vh] p-4 md:min-h-full">
           <div className="w-full max-w-sm py-8 space-y-6">
             <div className="text-center space-y-3">
               <div className="inline-flex items-center justify-center size-14 rounded-full bg-muted">

--- a/src/app/[locale]/panel-preview/page.tsx
+++ b/src/app/[locale]/panel-preview/page.tsx
@@ -42,9 +42,9 @@ export default function PanelPreviewPage() {
   // stuck on skeletons forever; offer an explicit retry instead.
   if (plannerError) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
         {renderHeader(true)}
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        <div className="p-4 md:min-h-0 md:flex-1 md:overflow-y-auto">
           <DataLoadError onRetry={retryPlannerData} />
         </div>
       </div>
@@ -55,9 +55,9 @@ export default function PanelPreviewPage() {
   // via getPlannerGameData()/getWikiWeaponSummaries() once this resolves.
   if (!plannerData) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
         {renderHeader(true)}
-        <div className="grid min-h-0 flex-1 gap-4 overflow-hidden p-4 xl:grid-cols-[minmax(34rem,1.35fr)_minmax(22rem,0.65fr)]">
+        <div className="grid gap-4 p-4 md:min-h-0 md:flex-1 md:overflow-hidden xl:grid-cols-[minmax(34rem,1.35fr)_minmax(22rem,0.65fr)]">
           <div className="flex min-h-0 flex-col gap-3">
             <Skeleton className="h-24 w-full rounded-lg" />
             <Skeleton className="min-h-0 w-full flex-1 rounded-xl" />
@@ -71,7 +71,7 @@ export default function PanelPreviewPage() {
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       {renderHeader(!config)}
       {isDesktop ? (
         <div className="min-h-0 flex-1 overflow-hidden xl:grid xl:grid-cols-[minmax(34rem,1.35fr)_minmax(22rem,0.65fr)]">
@@ -79,15 +79,15 @@ export default function PanelPreviewPage() {
           <aside className="min-h-0 overflow-y-auto p-4 pb-16"><PanelStatsSummary /></aside>
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div className="mx-4 mt-3 flex shrink-0 rounded-lg bg-muted p-0.5">
+        <div className="flex flex-col">
+          <div className="sticky top-0 z-30 mx-4 mt-3 flex shrink-0 rounded-lg bg-background/95 p-0.5 backdrop-blur">
             <Button type="button" variant="ghost" aria-pressed={mobileView === 'configuration'} onClick={() => setMobileView('configuration')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'configuration' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('configurationTab')}</Button>
             <Button type="button" variant="ghost" aria-pressed={mobileView === 'stats'} onClick={() => setMobileView('stats')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'stats' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('statsTab')}</Button>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="pb-2">
             {mobileView === 'configuration' ? <section className="space-y-6 p-4 pb-16"><CharacterPanelConfig /><EquipmentWeaponConfig /></section> : <aside className="p-4 pb-16"><PanelStatsSummary /></aside>}
           </div>
-          <div className="safe-area-mb relative z-40 flex shrink-0 justify-end bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
+          <div className="sticky bottom-0 safe-area-mb relative z-40 flex shrink-0 justify-end bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
             <Button type="button" variant={mobileView === 'configuration' ? 'default' : 'outline'} size="sm" onClick={() => setMobileView(mobileView === 'configuration' ? 'stats' : 'configuration')} disabled={mobileView === 'configuration' && !config}>{mobileView === 'configuration' ? t('viewStats') : t('editConfiguration')}</Button>
           </div>
         </div>

--- a/src/app/[locale]/panel-preview/page.tsx
+++ b/src/app/[locale]/panel-preview/page.tsx
@@ -79,15 +79,16 @@ export default function PanelPreviewPage() {
           <aside className="min-h-0 overflow-y-auto p-4 pb-16"><PanelStatsSummary /></aside>
         </div>
       ) : (
-        <div className="flex flex-col">
-          <div className="sticky top-0 z-30 mx-4 mt-3 flex shrink-0 rounded-lg bg-background/95 p-0.5 backdrop-blur">
+        /* <xl（isDesktop=false）：md–xl 时外层 overflow-hidden，此容器自滚；<md 由布局滚动壳滚。 */
+        <div className="flex flex-col md:min-h-0 md:flex-1">
+          <div className="sticky top-0 z-40 mx-4 mt-3 flex shrink-0 rounded-lg bg-muted p-0.5">
             <Button type="button" variant="ghost" aria-pressed={mobileView === 'configuration'} onClick={() => setMobileView('configuration')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'configuration' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('configurationTab')}</Button>
             <Button type="button" variant="ghost" aria-pressed={mobileView === 'stats'} onClick={() => setMobileView('stats')} className={cn('h-auto flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors', mobileView === 'stats' ? 'bg-background text-foreground shadow-[var(--shadow-raised)]' : 'text-muted-foreground')}>{t('statsTab')}</Button>
           </div>
-          <div className="pb-2">
+          <div className="pb-24 md:min-h-0 md:flex-1 md:overflow-y-auto">
             {mobileView === 'configuration' ? <section className="space-y-6 p-4 pb-16"><CharacterPanelConfig /><EquipmentWeaponConfig /></section> : <aside className="p-4 pb-16"><PanelStatsSummary /></aside>}
           </div>
-          <div className="sticky bottom-0 safe-area-mb relative z-40 flex shrink-0 justify-end bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
+          <div className="fixed inset-x-0 bottom-0 safe-area-bottom-bar z-40 flex shrink-0 justify-end bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
             <Button type="button" variant={mobileView === 'configuration' ? 'default' : 'outline'} size="sm" onClick={() => setMobileView(mobileView === 'configuration' ? 'stats' : 'configuration')} disabled={mobileView === 'configuration' && !config}>{mobileView === 'configuration' ? t('viewStats') : t('editConfiguration')}</Button>
           </div>
         </div>

--- a/src/app/[locale]/refinement-planner/page.tsx
+++ b/src/app/[locale]/refinement-planner/page.tsx
@@ -33,7 +33,7 @@ export default function RefinementPlannerPage() {
         description={t('meta.refinementPlannerDescription')}
         url={`${siteUrl}${pathname}`}
       />
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+      <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
         {/* Top bar */}
         <div className="flex items-center gap-3 px-4 py-2 border-b border-border">
           <SidebarTrigger />
@@ -56,8 +56,9 @@ export default function RefinementPlannerPage() {
         </div>
       </div>
 
-      {/* Mobile layout: segmented control + single panel + bottom bar */}
-      <div className="flex md:hidden flex-col flex-1 overflow-hidden">
+      {/* Mobile layout: segmented control + single panel + bottom bar.
+          内容高度由外层滚动壳承载，底栏 sticky 贴底。 */}
+      <div className="flex md:hidden flex-col">
         {/* Segmented control */}
         <div className="flex mx-4 mt-3 rounded-lg bg-muted p-0.5">
           <Button
@@ -90,8 +91,8 @@ export default function RefinementPlannerPage() {
           </Button>
         </div>
 
-        {/* Content area — min-h-0 prevents flex overflow if layout chain breaks */}
-        <div className="flex-1 min-h-0 overflow-y-auto">
+        {/* Content area — mobile 由布局滚动壳滚动 */}
+        <div className="pb-2">
           {mobileView === 'equips' ? (
             <div className="p-3 pb-16">
               <EquipList />
@@ -115,9 +116,9 @@ export default function RefinementPlannerPage() {
           )}
         </div>
 
-        {/* Bottom bar — relative with margin-bottom for watermark clearance.
+        {/* Bottom bar — sticky with margin-bottom for watermark clearance.
             safe-area-inset handled via safe-area-mb utility. */}
-        <div className="relative safe-area-mb z-40 flex items-center justify-between px-4 py-2.5 shadow-[var(--shadow-border-inset-t)] bg-background">
+        <div className="sticky bottom-0 relative safe-area-mb z-40 flex items-center justify-between px-4 py-2.5 shadow-[var(--shadow-border-inset-t)] bg-background">
           <span className="text-sm text-muted-foreground">
             {hasSelection
               ? t('refinement.hasSelection')

--- a/src/app/[locale]/refinement-planner/page.tsx
+++ b/src/app/[locale]/refinement-planner/page.tsx
@@ -57,10 +57,10 @@ export default function RefinementPlannerPage() {
       </div>
 
       {/* Mobile layout: segmented control + single panel + bottom bar.
-          内容高度由外层滚动壳承载，底栏 sticky 贴底。 */}
+          内容由布局滚动壳滚动；分段控件 sticky 钉在滚动壳顶部。 */}
       <div className="flex md:hidden flex-col">
-        {/* Segmented control */}
-        <div className="flex mx-4 mt-3 rounded-lg bg-muted p-0.5">
+        {/* Segmented control — sticky 钉在滚动壳顶；z-40 盖过装备卡角标的 z-30 */}
+        <div className="sticky top-0 z-40 mx-4 mt-3 flex shrink-0 rounded-lg bg-muted p-0.5">
           <Button
             type="button"
             variant="ghost"
@@ -92,13 +92,13 @@ export default function RefinementPlannerPage() {
         </div>
 
         {/* Content area — mobile 由布局滚动壳滚动 */}
-        <div className="pb-2">
+        <div className="pb-24">
           {mobileView === 'equips' ? (
-            <div className="p-3 pb-16">
+            <div className="p-3">
               <EquipList />
             </div>
           ) : (
-            <div className="p-4 pb-16">
+            <div className="p-4">
               {/* Selected equip context header */}
               {hasSelection && (
                 <Button
@@ -116,9 +116,9 @@ export default function RefinementPlannerPage() {
           )}
         </div>
 
-        {/* Bottom bar — sticky with margin-bottom for watermark clearance.
-            safe-area-inset handled via safe-area-mb utility. */}
-        <div className="sticky bottom-0 relative safe-area-mb z-40 flex items-center justify-between px-4 py-2.5 shadow-[var(--shadow-border-inset-t)] bg-background">
+        {/* Bottom bar — fixed so it stays reachable while the layout shell scrolls.
+            Parent is md:hidden, desktop unaffected. */}
+        <div className="fixed inset-x-0 bottom-0 safe-area-bottom-bar z-40 flex items-center justify-between bg-background px-4 py-2.5 shadow-[var(--shadow-border-inset-t)]">
           <span className="text-sm text-muted-foreground">
             {hasSelection
               ? t('refinement.hasSelection')

--- a/src/app/[locale]/settings/page.tsx
+++ b/src/app/[locale]/settings/page.tsx
@@ -90,14 +90,14 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
       {/* Top bar */}
-      <div className="flex items-center gap-3 px-4 py-2 shadow-[var(--shadow-border-b)]">
+      <div className="sticky top-0 z-30 flex items-center gap-3 border-b border-border bg-background/95 px-4 py-2 backdrop-blur">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">{t('nav.settings')}</h1>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-4">
+      <div className="p-4 md:flex-1 md:overflow-y-auto">
         <div className="flex w-full max-w-none flex-col gap-6">
         {/* 主题设置组 */}
         <section className="flex flex-col gap-4">

--- a/src/app/[locale]/tools/game-i18n/page.tsx
+++ b/src/app/[locale]/tools/game-i18n/page.tsx
@@ -7,7 +7,7 @@ import { GameI18nLookupPanel } from '@/components/tools/game-i18n-lookup-panel'
 export default function GameI18nLookupPage() {
   const t = useTranslations('gameI18nLookup')
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 px-4 py-2 shadow-[var(--shadow-border)]">
         <SidebarTrigger />
         <h1 className="min-w-0 truncate text-base font-semibold tracking-tight">{t('title')}</h1>

--- a/src/app/[locale]/update/page.tsx
+++ b/src/app/[locale]/update/page.tsx
@@ -182,9 +182,9 @@ export default function UpdatePage() {
   const displayInfo = localInfo ?? info
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
       {/* Top bar */}
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-border">
+      <div className="flex items-center gap-3 border-b border-border px-4 py-2">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">
           {t('nav.update')}
@@ -192,7 +192,7 @@ export default function UpdatePage() {
       </div>
 
       {/* Main content */}
-      <div className="flex-1 overflow-y-scroll p-8 flex items-start justify-center">
+      <div className="flex items-start justify-center p-8 md:min-h-0 md:flex-1 md:overflow-y-scroll">
         <div className="w-full max-w-lg">
           {/* Version comparison */}
           {isUpdateAvailable && localInfo && info ? (

--- a/src/app/[locale]/wiki/characters/[id]/page.tsx
+++ b/src/app/[locale]/wiki/characters/[id]/page.tsx
@@ -60,7 +60,7 @@ export default async function WikiCharacterDetailPage({ params }: { params: Prom
   }))
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 px-4 py-2 shadow-[var(--shadow-border)] sm:px-6 lg:px-8">
         <SidebarTrigger />
         <NavLink

--- a/src/app/[locale]/wiki/characters/page.tsx
+++ b/src/app/[locale]/wiki/characters/page.tsx
@@ -28,7 +28,7 @@ export default async function WikiCharactersPage({ params }: { params: Promise<{
   )
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 px-4 py-2 shadow-[var(--shadow-border)] sm:px-6 lg:px-8">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">

--- a/src/app/[locale]/wiki/equipment/[id]/page.tsx
+++ b/src/app/[locale]/wiki/equipment/[id]/page.tsx
@@ -53,7 +53,7 @@ export default async function WikiEquipmentDetailPage({ params }: { params: Prom
   }))
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 px-4 py-2 shadow-[var(--shadow-border)] sm:px-6 lg:px-8">
         <SidebarTrigger />
         <NavLink

--- a/src/app/[locale]/wiki/equipment/page.tsx
+++ b/src/app/[locale]/wiki/equipment/page.tsx
@@ -28,7 +28,7 @@ export default async function WikiEquipmentPage({ params }: { params: Promise<{ 
   )
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 px-4 py-2 shadow-[var(--shadow-border)] sm:px-6 lg:px-8">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">

--- a/src/app/[locale]/wiki/weapons/[id]/page.tsx
+++ b/src/app/[locale]/wiki/weapons/[id]/page.tsx
@@ -42,7 +42,7 @@ export default async function WikiWeaponDetailPage({ params }: { params: Promise
   const weaponType = t(`wikiData.enum|weaponTypes|${weapon.weaponTypeId}`)
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 px-4 py-2 shadow-[var(--shadow-border)] sm:px-6 lg:px-8">
         <SidebarTrigger />
         <NavLink

--- a/src/app/[locale]/wiki/weapons/page.tsx
+++ b/src/app/[locale]/wiki/weapons/page.tsx
@@ -28,7 +28,7 @@ export default async function WikiWeaponsPage({ params }: { params: Promise<{ lo
   )
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 px-4 py-2 shadow-[var(--shadow-border)] sm:px-6 lg:px-8">
         <SidebarTrigger />
         <h1 className="text-base font-semibold tracking-tight">

--- a/src/components/banner-calendar/banner-calendar.tsx
+++ b/src/components/banner-calendar/banner-calendar.tsx
@@ -94,7 +94,7 @@ export function BannerCalendar() {
   const hasStandard = timelineData && timelineData.standardChars.length > 0
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+    <div className="flex flex-col md:flex-1 md:min-h-0 md:overflow-hidden">
       {/* Top bar: title + controls inline */}
       <div className="flex items-center gap-2 px-4 py-2 shadow-[var(--shadow-border-b)] shrink-0">
         <SidebarTrigger />
@@ -131,7 +131,7 @@ export function BannerCalendar() {
       )}
 
       {/* Main timeline - fills available space, vertical scroll on overflow */}
-      <div className="flex-1 min-h-0 overflow-y-auto px-4 pt-2 pb-0">
+      <div className="px-4 pt-2 pb-0 md:min-h-0 md:flex-1 md:overflow-y-auto">
         {hasData ? (
           <TimelineChart data={timelineData} t={t} />
         ) : (

--- a/src/components/shared/ad-slot.tsx
+++ b/src/components/shared/ad-slot.tsx
@@ -21,7 +21,8 @@ export interface AdSlotProps {
  */
 const VARIANT_SIZE_CLASS: Record<AdSlotVariant, string> = {
   desktop: 'h-full w-auto aspect-[280/380]',
-  mobile: 'h-[100px] w-[320px]',
+  // max-w-full：320px 视口下避免与外层 padding 叠加产生横向溢出。
+  mobile: 'h-[100px] w-[320px] max-w-full',
 }
 
 /**

--- a/src/components/shared/ad-slot.tsx
+++ b/src/components/shared/ad-slot.tsx
@@ -30,8 +30,9 @@ const VARIANT_SIZE_CLASS: Record<AdSlotVariant, string> = {
  * （新标签页打开），点击瞬间用 navigator.sendBeacon 异步上报点击 —— 不经过
  * 后端中转跳转，也不阻塞新标签页。
  *
- * 素材为运营服务托管的 gif 动图 —— next/image 的优化管线会破坏动画且
- * 需要远程域名白名单，故使用原生 <img>（有 announcement-panel 先例）。
+ * 素材为运营服务托管的图片（GIF / JPEG / PNG / WebP，含动图）—— next/image
+ * 的优化管线会破坏 gif 动画且需要远程域名白名单，故使用原生 <img>（有
+ * announcement-panel 先例）。
  */
 export function AdSlot({ variant, className }: AdSlotProps) {
   useAdPolling()
@@ -52,7 +53,7 @@ export function AdSlot({ variant, className }: AdSlotProps) {
   }
 
   const image = (
-    // eslint-disable-next-line @next/next/no-img-element -- gif 动图必须绕过 next/image 优化（见组件注释）
+    // eslint-disable-next-line @next/next/no-img-element -- 运营服务托管图片（含 gif 动图）必须绕过 next/image 优化（见组件注释）
     <img
       src={(variant === 'desktop' ? ad.desktopImageUrl : ad.mobileImageUrl) ?? ''}
       alt={ad.title.length > 0 ? ad.title : t('ad.imageAlt')}

--- a/src/components/shared/mobile-ad-banner.tsx
+++ b/src/components/shared/mobile-ad-banner.tsx
@@ -3,13 +3,14 @@
 import { AdSlot } from './ad-slot'
 
 /**
- * 移动端顶部广告 banner（320x100）。挂在 [locale] 布局的横幅栈最上方，
- * 仅移动端显示（md:hidden）；非 sticky，不遮挡页面内容。
+ * 移动端顶部广告 banner（320x100）。挂在 [locale] 布局的内容滚动壳顶部，
+ * 与页面内容同一滚动上下文，随内容一起滚出视口；仅移动端显示（md:hidden）。
+ * 不做成整宽背景条，避免观感上像独立顶栏。
  */
 export function MobileAdBanner() {
   return (
-    <div className="flex shrink-0 justify-center bg-background md:hidden">
-      <AdSlot variant="mobile" className="my-2" />
+    <div className="flex shrink-0 justify-center px-4 pt-3 pb-1 md:hidden">
+      <AdSlot variant="mobile" />
     </div>
   )
 }

--- a/src/components/shared/mobile-ad-banner.tsx
+++ b/src/components/shared/mobile-ad-banner.tsx
@@ -9,7 +9,7 @@ import { AdSlot } from './ad-slot'
  */
 export function MobileAdBanner() {
   return (
-    <div className="flex shrink-0 justify-center px-4 pt-3 pb-1 md:hidden">
+    <div className="flex shrink-0 justify-center px-0 pt-3 pb-1 sm:px-4 md:hidden">
       <AdSlot variant="mobile" />
     </div>
   )

--- a/src/components/tools/game-i18n-lookup-panel.tsx
+++ b/src/components/tools/game-i18n-lookup-panel.tsx
@@ -552,7 +552,7 @@ export function GameI18nLookupPanel() {
   const canReloadResources = error === 'manifestMissing' || error === 'prefetchFailed'
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-4 sm:p-6">
+    <div className="flex flex-col gap-4 p-4 sm:p-6 md:min-h-0 md:flex-1 md:overflow-hidden">
       <div className="shrink-0 space-y-3 rounded-xl bg-card p-4 shadow-[var(--shadow-border)]">
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
           <div className="grid w-full gap-1.5 sm:w-auto sm:min-w-[10rem]">
@@ -624,7 +624,7 @@ export function GameI18nLookupPanel() {
         ) : null}
       </div>
 
-      <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+      <div className="grid gap-4 md:min-h-0 md:flex-1 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
         <div className="min-h-0 overflow-auto rounded-xl bg-card shadow-[var(--shadow-border)]">
           <Table className="table-fixed" role="grid">
             <TableHeader>

--- a/src/components/wiki/wiki-detail-interactive.tsx
+++ b/src/components/wiki/wiki-detail-interactive.tsx
@@ -83,7 +83,7 @@ export function WikiDetailShell({ children, tocItems }: WikiDetailShellProps) {
   return (
     <div
       ref={scrollRef}
-      className="relative min-h-0 min-w-0 flex-1 overflow-y-auto"
+      className="relative min-w-0 md:min-h-0 md:flex-1 md:overflow-y-auto"
       onScroll={updateActiveSection}
     >
       <div className="w-full min-w-0 px-3 py-4 sm:px-5 sm:py-5 lg:px-6">{children}</div>

--- a/src/components/wiki/wiki-detail-interactive.tsx
+++ b/src/components/wiki/wiki-detail-interactive.tsx
@@ -40,6 +40,25 @@ export interface WikiDetailShellProps {
   tocItems: WikiTocItem[]
 }
 
+/** overflowY 可能被 Chromium 映射为 overlay，一并识别。 */
+function isScrollableOverflow(overflowY: string): boolean {
+  return overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay'
+}
+
+/**
+ * 真正发生滚动的祖先：md+ 是 shell 自身（overflow-y-auto），md 以下是布局
+ * 滚动壳（shell 不滚）。找不到则回退 document。
+ */
+function resolveWikiScrollRoot(el: HTMLElement | null): Element | null {
+  if (!el) return null
+  let node: HTMLElement | null = el
+  while (node) {
+    if (isScrollableOverflow(window.getComputedStyle(node).overflowY)) return node
+    node = node.parentElement
+  }
+  return document.scrollingElement
+}
+
 export function WikiDetailShell({ children, tocItems }: WikiDetailShellProps) {
   const [tocExpanded, setTocExpanded] = useState(false)
   const [activeTocId, setActiveTocId] = useState(tocItems[0]?.id ?? '')
@@ -48,7 +67,7 @@ export function WikiDetailShell({ children, tocItems }: WikiDetailShellProps) {
 
   const updateActiveSection = useCallback(() => {
     setTocExpanded(false)
-    const scrollRoot = scrollRef.current
+    const scrollRoot = resolveWikiScrollRoot(scrollRef.current)
     if (!scrollRoot) return
     const rootTop = scrollRoot.getBoundingClientRect().top
     let active = tocItems[0]?.id ?? ''
@@ -60,7 +79,7 @@ export function WikiDetailShell({ children, tocItems }: WikiDetailShellProps) {
   }, [tocItems])
 
   const initializeActiveSection = useCallback(() => {
-    const scrollRoot = scrollRef.current
+    const scrollRoot = resolveWikiScrollRoot(scrollRef.current)
     if (!scrollRoot) return
     const rootTop = scrollRoot.getBoundingClientRect().top
     let active = tocItems[0]?.id ?? ''
@@ -76,6 +95,25 @@ export function WikiDetailShell({ children, tocItems }: WikiDetailShellProps) {
     return () => window.cancelAnimationFrame(frame)
   }, [initializeActiveSection])
 
+  // 绑定到实际滚动容器：md+ 是 shell，md 以下是布局滚动壳；断点切换时重绑。
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    let scroller = resolveWikiScrollRoot(el)
+    const onScroll = () => updateActiveSection()
+    const rebind = () => {
+      scroller?.removeEventListener('scroll', onScroll)
+      scroller = resolveWikiScrollRoot(el)
+      scroller?.addEventListener('scroll', onScroll, { passive: true })
+    }
+    rebind()
+    window.addEventListener('resize', rebind)
+    return () => {
+      scroller?.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', rebind)
+    }
+  }, [updateActiveSection])
+
   useEffect(() => () => {
     if (scrollTimerRef.current !== null) window.clearInterval(scrollTimerRef.current)
   }, [])
@@ -84,7 +122,6 @@ export function WikiDetailShell({ children, tocItems }: WikiDetailShellProps) {
     <div
       ref={scrollRef}
       className="relative min-w-0 md:min-h-0 md:flex-1 md:overflow-y-auto"
-      onScroll={updateActiveSection}
     >
       <div className="w-full min-w-0 px-3 py-4 sm:px-5 sm:py-5 lg:px-6">{children}</div>
       <WikiDetailToc
@@ -93,7 +130,7 @@ export function WikiDetailShell({ children, tocItems }: WikiDetailShellProps) {
         expanded={tocExpanded}
         onExpandedChange={setTocExpanded}
         onNavigate={(id) => {
-          const scrollRoot = scrollRef.current
+          const scrollRoot = resolveWikiScrollRoot(scrollRef.current)
           const section = document.getElementById(id)
           if (!scrollRoot || !section) return
           setActiveTocId(id)

--- a/src/components/wiki/wiki-entity-grid.tsx
+++ b/src/components/wiki/wiki-entity-grid.tsx
@@ -564,7 +564,7 @@ export const WikiEntityGrid = memo(function WikiEntityGrid({
     ? t('wiki.resultCountFiltered', { count: filtered.length, total: entities.length })
     : t('wiki.resultCount', { count: filtered.length })
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex flex-col md:min-h-0 md:flex-1 md:overflow-hidden">
       <div className="shrink-0 space-y-3 px-4 py-4 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-2">
           <div className="relative flex items-center">
@@ -649,7 +649,7 @@ export const WikiEntityGrid = memo(function WikiEntityGrid({
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 pb-6 sm:px-6 lg:px-8">
+      <div className="px-4 pb-6 sm:px-6 lg:px-8 md:flex-1 md:overflow-y-auto">
         {filtered.length === 0 ? (
           <div className="mx-auto mt-10 flex max-w-sm flex-col items-center gap-3 rounded-lg bg-card p-6 text-center shadow-[var(--shadow-card)]">
             <SearchX aria-hidden="true" className="size-8 text-muted-foreground" />

--- a/src/data/banner.ts
+++ b/src/data/banner.ts
@@ -42,7 +42,7 @@ export const bannerEntries: BannerEntry[] = [
     version: '1.5',
     periodStart: '2026-09-24T12:00:00+08:00',
     periodEnd: '2026-10-14T11:59:00+08:00',
-    featured: [{ name: '伊冯', period: 11 }],
+    featured: [{ name: '伊冯', period: 12 }],
   },
   {
     id: '1.5-tifuluosi',
@@ -54,7 +54,7 @@ export const bannerEntries: BannerEntry[] = [
     version: '1.5',
     periodStart: '2026-09-02T12:00:00+08:00',
     periodEnd: '2026-09-30T11:59:00+08:00',
-    featured: [{ name: '提弗洛斯', period: 10 }],
+    featured: [{ name: '提弗洛斯', period: 11 }],
   },
   {
     id: '1.4-jue',

--- a/src/types/ad.ts
+++ b/src/types/ad.ts
@@ -3,9 +3,9 @@ export interface AdItem {
   id: number
   /** Alt text from the admin console (optional); empty string falls back to the i18n label. */
   title: string
-  /** 280x380 creative URL; null when this ad has no desktop creative — the desktop slot then renders nothing. */
+  /** 280x380 creative URL (GIF/JPEG/PNG/WebP); null when this ad has no desktop creative — the desktop slot then renders nothing. */
   desktopImageUrl: string | null
-  /** 320x100 creative URL; null when this ad has no mobile creative — the mobile banner then renders nothing. */
+  /** 320x100 creative URL (GIF/JPEG/PNG/WebP); null when this ad has no mobile creative — the mobile banner then renders nothing. */
   mobileImageUrl: string | null
   /** Direct https target link; null when the ad is a pure display creative. */
   targetUrl: string | null


### PR DESCRIPTION
## Sourcery 摘要

修复整个应用中的响应式移动端布局和横幅展示，同时保留桌面端的滚动行为。

错误修复：
- 通过将移动端内容和广告移至共享滚动布局中，改进移动端横幅和页面适配，避免应用各页面出现溢出和视口高度问题。
- 通过固定标签选择器和固定底部操作栏，确保移动端规划器控件始终可访问。
- 修正 wiki 目录跟踪和导航问题，以适应移动端和桌面端活动滚动容器不同的情况。
- 防止移动端广告溢出狭窄的视口。

增强功能：
- 统一响应式页面布局行为：在中等及更大屏幕上保留内部滚动，而移动端页面使用布局级滚动容器。
- 确保移动端页面标题和规划器控件在滚动过程中保持可见。
- 更新横幅日程角色周期元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix responsive mobile layouts and banner presentation across the application while preserving desktop scrolling behavior.

Bug Fixes:
- Improve mobile banner and page adaptation by moving mobile content and advertising into a shared scrolling layout, preventing overflow and viewport-height issues across application pages.
- Keep mobile planner controls accessible with sticky tab selectors and fixed bottom action bars.
- Correct wiki table-of-contents tracking and navigation when the active scroll container differs between mobile and desktop.
- Prevent mobile advertisements from overflowing narrow viewports.

Enhancements:
- Standardize responsive page layout behavior so internal scrolling is retained on medium and larger screens while mobile pages use the layout-level scroll container.
- Keep mobile page headers and planner controls visible during scrolling.
- Update banner schedule character period metadata.

</details>

<details>
<summary>Original summary in English</summary>



</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化多页面响应式布局，移动端内容改为自然滚动，减少桌面端高度和溢出约束带来的显示问题。
  * 在多个页面增加吸顶标题栏、标签栏和底部操作栏，提升移动端浏览与操作体验。
  * 优化移动端广告与页面内容的滚动衔接，并为部分嵌入内容提供更合适的最小高度。
* **文档**
  * 补充广告素材支持的图片格式说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->