### PR TITLE
fix: 修复精锻规划材料文本解析异常,调整默认制造材料显示为最新材料

### DIFF
--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -756,6 +756,53 @@ function checkClientBagCoverage(allFiles, globalConstants) {
   return { errors, warnings }
 }
 
+// ─── Phase 2e: Game catalog item integrity ──────────────────────────────────
+
+function checkGameCatalogIntegrity() {
+  const errors = []
+  const warnings = []
+  const wikiDataDir = join(ROOT, 'src', 'generated', 'i18n', 'wikiData')
+  const wikiDataSrcDir = join(ROOT, 'src', 'generated', 'data', 'wiki')
+
+  if (!existsSync(wikiDataDir) || !existsSync(wikiDataSrcDir)) {
+    return { errors, warnings }
+  }
+
+  const itemIds = new Set()
+  function scanDir(dir) {
+    if (!existsSync(dir)) return
+    for (const f of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, f.name)
+      if (f.isDirectory()) scanDir(full)
+      else if (f.name.endsWith('.json') || f.name.endsWith('.ts')) {
+        const content = readFileSync(full, 'utf-8')
+        for (const m of content.matchAll(/"itemId":\s*"([^"]+)"/g)) itemIds.add(m[1])
+      }
+    }
+  }
+  scanDir(wikiDataSrcDir)
+
+  const locales = ['zh-CN', 'en', 'ja', 'zh-TW']
+  for (const loc of locales) {
+    const filePath = join(wikiDataDir, `${loc}.json`)
+    if (!existsSync(filePath)) {
+      errors.push(`[P0] 缺少游戏字典文件：src/generated/i18n/wikiData/${loc}.json`)
+      continue
+    }
+    const catalog = JSON.parse(readFileSync(filePath, 'utf-8'))
+    for (const itemId of itemIds) {
+      const key = `item|${itemId}`
+      if (!catalog[key]) {
+        errors.push(
+          `[P0] 材料 "${itemId}" 缺少 ${loc} 语言游戏字典（缺少键 "${key}" 于 generated/i18n/wikiData/${loc}.json）`
+        )
+      }
+    }
+  }
+
+  return { errors, warnings }
+}
+
 // Shell namespaces = top-level keys of the messages JSONs (filled in main()).
 const SHELL_NAMESPACES = new Set()
 
@@ -872,8 +919,11 @@ function main() {
   // Phase 2d: Client bag coverage (core shell + per-route injection)
   const bagResult = checkClientBagCoverage(allFiles, globalConstants)
 
-  const errors = [...phase3.errors, ...ecResult.errors, ...bagResult.errors]
-  const warnings = [...phase3.warnings, ...ecResult.warnings, ...bagResult.warnings]
+  // Phase 2e: Game catalog item integrity (planner materials coverage)
+  const gameCatalogResult = checkGameCatalogIntegrity()
+
+  const errors = [...phase3.errors, ...ecResult.errors, ...bagResult.errors, ...gameCatalogResult.errors]
+  const warnings = [...phase3.warnings, ...ecResult.warnings, ...bagResult.warnings, ...gameCatalogResult.warnings]
   const info = phase3.info
   const exitCode = errors.length > 0 ? 1 : phase3.exitCode
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -35,6 +35,7 @@ import { UpdateChangelogNotice } from '@/components/shared/update-changelog-noti
 import { DEFAULT_SITE_URL } from '@/lib/constants'
 import { IS_DEV_BUILD } from '@/lib/build-flags'
 import { GameI18nCatalogPreloader } from '@/components/shared/game-i18n-catalog-preloader'
+import { MissingTranslationNotifier } from '@/components/shared/missing-translation-notifier'
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }))
@@ -99,6 +100,7 @@ export default async function LocaleLayout({
             <AnnouncementLoader />
             <SyncManager />
             <UpdateChangelogNotice />
+            <MissingTranslationNotifier />
             <LegacyMigrationDialog />
             <Background />
             <AppSidebar />

--- a/src/components/refinement/equip-card.test.ts
+++ b/src/components/refinement/equip-card.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest'
-import { getPlannerStatPreview, splitPlannerRecipes } from './equip-card'
+import { getLatestCraftingRecipe, getPlannerStatPreview, splitPlannerRecipes } from './equip-card'
 import type { WikiCraftingRecipe } from '@/types/wiki'
 import type { Equip } from '@/types/refinement'
 import type { WikiEquipmentPlannerPreview } from '@/types/wiki'
@@ -20,6 +20,18 @@ it('shows default and discounted recipes before collapsing ordinary alternatives
     featured: [defaultRecipe, discountedRecipe],
     other: [ordinaryRecipe],
   })
+})
+
+it('selects discounted recipe with highest chainId as latest crafting recipe', () => {
+  const defaultRecipe = recipe(4000, true, 1)
+  const altRecipe = recipe(4001, false, 1)
+  const discountedRecipe1 = recipe(4002, false, 0.5)
+  const discountedRecipe2 = recipe(4003, false, 0.01)
+
+  expect(getLatestCraftingRecipe([defaultRecipe, altRecipe, discountedRecipe1, discountedRecipe2])).toEqual(discountedRecipe2)
+  expect(getLatestCraftingRecipe([defaultRecipe, altRecipe])).toEqual(defaultRecipe)
+  expect(getLatestCraftingRecipe([altRecipe])).toEqual(altRecipe)
+  expect(getLatestCraftingRecipe([])).toBeUndefined()
 })
 
 it('uses slot order when an equipment repeats the same attribute ID', () => {

--- a/src/components/refinement/equip-card.tsx
+++ b/src/components/refinement/equip-card.tsx
@@ -46,12 +46,26 @@ const MODEL_I18N_MAP: Record<string, string> = {
 }
 
 export function splitPlannerRecipes<T extends Pick<WikiCraftingRecipe, 'chainId' | 'discount' | 'isDefault'>>(recipes: T[]) {
-  const featured = recipes.filter((recipe) => recipe.isDefault || (recipe.discount > 0 && recipe.discount < 1)).sort((left, right) => Number(right.isDefault) - Number(left.isDefault))
+  const featured = recipes
+    .filter((recipe) => recipe.isDefault || (recipe.discount > 0 && recipe.discount < 1))
+    .sort((left, right) => {
+      const defaultDiff = Number(right.isDefault) - Number(left.isDefault)
+      if (defaultDiff !== 0) return defaultDiff
+      return right.chainId - left.chainId
+    })
   const featuredIds = new Set(featured.map((recipe) => recipe.chainId))
   return {
     featured,
     other: recipes.filter((recipe) => !featuredIds.has(recipe.chainId)),
   }
+}
+
+export function getLatestCraftingRecipe<T extends Pick<WikiCraftingRecipe, 'chainId' | 'discount' | 'isDefault'>>(recipes: T[]): T | undefined {
+  const discounted = recipes
+    .filter((recipe) => recipe.discount > 0 && recipe.discount < 1)
+    .sort((left, right) => right.chainId - left.chainId)
+  if (discounted.length > 0) return discounted[0]
+  return recipes.find((recipe) => recipe.isDefault) ?? recipes[0]
 }
 
 export function getPlannerStatPreview(

--- a/src/components/refinement/refinement-panel.tsx
+++ b/src/components/refinement/refinement-panel.tsx
@@ -15,7 +15,7 @@ import { withImageCacheVersion } from '@/lib/image-url'
 import { WikiMaterialList } from '@/components/shared/wiki-material-list'
 import { ItemFrameBackground } from '@/components/shared/item-frame-background'
 import { wikiEquipmentPlannerPreviews } from '@/generated/data/wiki/planner-previews'
-import { splitPlannerRecipes } from './equip-card'
+import { getLatestCraftingRecipe } from './equip-card'
 
 // Map Chinese equip types to i18n keys
 const TYPE_TO_KEY: Record<string, string> = {
@@ -33,12 +33,9 @@ export const RefinementPanel = memo(function RefinementPanel() {
   const isMobile = useIsMobile()
   const [expandedRecipeEquipId, setExpandedRecipeEquipId] = useState<string | null>(null)
   const selectedWikiPreview = selected ? wikiEquipmentPlannerPreviews[selected.id] : undefined
-  const recipeGroups = splitPlannerRecipes(selectedWikiPreview?.craftingRecipes ?? [])
-  const defaultRecipe = recipeGroups.featured.find((recipe) => recipe.isDefault)
-    ?? recipeGroups.featured[0]
-    ?? recipeGroups.other[0]
-  const alternativeRecipes = [...recipeGroups.featured, ...recipeGroups.other]
-    .filter((recipe) => recipe.chainId !== defaultRecipe?.chainId)
+  const allRecipes = selectedWikiPreview?.craftingRecipes ?? []
+  const primaryRecipe = getLatestCraftingRecipe(allRecipes)
+  const alternativeRecipes = allRecipes.filter((recipe) => recipe.chainId !== primaryRecipe?.chainId)
   const showOtherRecipes = selected?.id === expandedRecipeEquipId
 
   return (
@@ -148,10 +145,21 @@ export const RefinementPanel = memo(function RefinementPanel() {
                     </span>
                   </div>
                   <div className="mt-1 space-y-2">
-                    <span className="text-xs text-muted-foreground">{t('refinement.material')}</span>
-                    {defaultRecipe ? (
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">{t('refinement.material')}</span>
+                      {primaryRecipe ? (
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-[11px] text-muted-foreground font-medium">{t('wiki.recipe')} #{primaryRecipe.chainId}</span>
+                          {primaryRecipe.isDefault ? <Badge>{t('wiki.defaultRecipe')}</Badge> : null}
+                          {primaryRecipe.discount > 0 && primaryRecipe.discount < 1 ? (
+                            <Badge variant="secondary" className="text-ship-red text-[10px] px-1.5 py-0">-{Math.round((1 - primaryRecipe.discount) * 100)}%</Badge>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
+                    {primaryRecipe ? (
                       <>
-                        <WikiMaterialList materials={defaultRecipe.materials} compact />
+                        <WikiMaterialList materials={primaryRecipe.materials} compact />
                         {alternativeRecipes.length > 0 ? (
                           <Button
                             type="button"
@@ -170,6 +178,7 @@ export const RefinementPanel = memo(function RefinementPanel() {
                               <div key={recipe.chainId} className="space-y-2 rounded-md bg-muted/35 p-2">
                                 <div className="flex flex-wrap items-center gap-1.5">
                                   <span className="text-[11px] font-medium">{t('wiki.recipe')} #{recipe.chainId}</span>
+                                  {recipe.isDefault ? <Badge>{t('wiki.defaultRecipe')}</Badge> : null}
                                   {recipe.discount > 0 && recipe.discount < 1 ? (
                                     <Badge variant="secondary" className="text-ship-red">-{Math.round((1 - recipe.discount) * 100)}%</Badge>
                                   ) : null}

--- a/src/components/refinement/slot-recommendation.tsx
+++ b/src/components/refinement/slot-recommendation.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import { getGridColumns } from '@/lib/grid-columns'
 import { Button } from '@/components/ui/button'
-import { EquipCard, splitPlannerRecipes } from './equip-card'
+import { EquipCard, getLatestCraftingRecipe } from './equip-card'
 import { useRefinementStore } from '@/stores/useRefinementStore'
 import type { SlotRecommendation } from '@/types/refinement'
 import { ChevronDown } from 'lucide-react'
@@ -147,10 +147,9 @@ export const SlotRecommendationCard = memo(function SlotRecommendationCard({
               </div>
               {(() => {
                 const preview = wikiEquipmentPlannerPreviews[c.equip.id]
-                const { featured, other } = splitPlannerRecipes(preview?.craftingRecipes ?? [])
-                const defaultRecipe = featured[0] ?? other[0]
-                return defaultRecipe ? (
-                  <WikiMaterialList materials={defaultRecipe.materials} compact iconOnly className="grid w-full grid-cols-2 gap-2" />
+                const latestRecipe = getLatestCraftingRecipe(preview?.craftingRecipes ?? [])
+                return latestRecipe ? (
+                  <WikiMaterialList materials={latestRecipe.materials} compact iconOnly className="grid w-full grid-cols-2 gap-2" />
                 ) : null
               })()}
             </div>

--- a/src/components/shared/missing-translation-notifier.test.tsx
+++ b/src/components/shared/missing-translation-notifier.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { MissingTranslationNotifier } from './missing-translation-notifier'
+import {
+  reportMissingTranslation,
+  resetMissingTranslationsForTests,
+} from '@/lib/missing-translation-guard'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: { key?: string }) => {
+    if (key === 'common.missingTranslationTitle') return '发现异常文本'
+    if (key === 'common.missingTranslationDesc') return `检测到 ${values?.key} 解析异常，欢迎向开发者反馈。`
+    if (key === 'common.copyReportInfo') return '复制反馈信息'
+    if (key === 'common.reportCopied') return '已复制'
+    if (key === 'common.reportToGithub') return '提交反馈'
+    if (key === 'common.close') return '关闭'
+    return key
+  },
+  useLocale: () => 'zh-CN',
+}))
+
+afterEach(() => {
+  cleanup()
+  resetMissingTranslationsForTests()
+})
+
+it('renders notification when a missing translation event is emitted', () => {
+  render(<MissingTranslationNotifier />)
+  expect(screen.queryByRole('alert')).toBeNull()
+
+  act(() => {
+    reportMissingTranslation({
+      key: 'item|item_unknown_script',
+      locale: 'zh-CN',
+      category: 'item',
+    })
+  })
+
+  expect(screen.getByRole('alert')).toBeTruthy()
+  expect(screen.getByText('发现异常文本')).toBeTruthy()
+  expect(screen.getByText('检测到 item|item_unknown_script 解析异常，欢迎向开发者反馈。')).toBeTruthy()
+  const link = screen.getByRole('link', { name: '提交反馈' })
+  expect(link.getAttribute('href')).toContain('item%7Citem_unknown_script')
+})

--- a/src/components/shared/missing-translation-notifier.test.tsx
+++ b/src/components/shared/missing-translation-notifier.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, render, screen } from '@testing-library/react'
-import { afterEach, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MissingTranslationNotifier } from './missing-translation-notifier'
 import {
   reportMissingTranslation,
@@ -21,26 +21,88 @@ vi.mock('next-intl', () => ({
   useLocale: () => 'zh-CN',
 }))
 
-afterEach(() => {
-  cleanup()
-  resetMissingTranslationsForTests()
-})
-
-it('renders notification when a missing translation event is emitted', () => {
-  render(<MissingTranslationNotifier />)
-  expect(screen.queryByRole('alert')).toBeNull()
-
-  act(() => {
-    reportMissingTranslation({
-      key: 'item|item_unknown_script',
-      locale: 'zh-CN',
-      category: 'item',
+describe('MissingTranslationNotifier', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...window.location,
+        origin: 'https://cep.app',
+        pathname: '/wiki/equipment',
+        search: '?token=secret123',
+        hash: '#test-hash',
+        href: 'https://cep.app/wiki/equipment?token=secret123#test-hash',
+      },
     })
   })
 
-  expect(screen.getByRole('alert')).toBeTruthy()
-  expect(screen.getByText('发现异常文本')).toBeTruthy()
-  expect(screen.getByText('检测到 item|item_unknown_script 解析异常，欢迎向开发者反馈。')).toBeTruthy()
-  const link = screen.getByRole('link', { name: '提交反馈' })
-  expect(link.getAttribute('href')).toContain('item%7Citem_unknown_script')
+  afterEach(() => {
+    cleanup()
+    resetMissingTranslationsForTests()
+  })
+
+  it('renders notification when a missing translation event is emitted while mounted', async () => {
+    render(<MissingTranslationNotifier />)
+    expect(screen.queryByRole('alert')).toBeNull()
+
+    await act(async () => {
+      reportMissingTranslation({
+        key: 'item|item_unknown_script',
+        locale: 'zh-CN',
+        category: 'item',
+      })
+    })
+
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByText('发现异常文本')).toBeTruthy()
+    expect(screen.getByText('检测到 item|item_unknown_script 解析异常，欢迎向开发者反馈。')).toBeTruthy()
+
+    const link = screen.getByRole('link', { name: '提交反馈' })
+    const href = link.getAttribute('href') ?? ''
+    expect(href).toContain('item%7Citem_unknown_script')
+    // Ensure URL context is sanitized (no query params or hash)
+    expect(href).toContain(encodeURIComponent('https://cep.app/wiki/equipment'))
+    expect(href).not.toContain('secret123')
+    expect(href).not.toContain('test-hash')
+  })
+
+  it('replays buffered event when reported before notifier mounts', async () => {
+    // 1. Report before component is mounted
+    reportMissingTranslation({
+      key: 'item|item_early_report',
+      locale: 'zh-CN',
+      category: 'item',
+    })
+
+    // 2. Mount notifier afterwards
+    await act(async () => {
+      render(<MissingTranslationNotifier />)
+    })
+
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByText('检测到 item|item_early_report 解析异常，欢迎向开发者反馈。')).toBeTruthy()
+  })
+
+  it('handles reporting during component render phase without breaking', async () => {
+    function ChildWithMissingKey() {
+      reportMissingTranslation({
+        key: 'item|item_during_render',
+        locale: 'zh-CN',
+        category: 'item',
+      })
+      return <div>Child Content</div>
+    }
+
+    await act(async () => {
+      render(
+        <div>
+          <MissingTranslationNotifier />
+          <ChildWithMissingKey />
+        </div>
+      )
+    })
+
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByText('检测到 item|item_during_render 解析异常，欢迎向开发者反馈。')).toBeTruthy()
+  })
 })

--- a/src/components/shared/missing-translation-notifier.tsx
+++ b/src/components/shared/missing-translation-notifier.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { AlertTriangle, Copy, ExternalLink, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button, buttonVariants } from '@/components/ui/button'
+import {
+  onMissingTranslation,
+  type MissingTranslationEvent,
+} from '@/lib/missing-translation-guard'
+
+export function MissingTranslationNotifier() {
+  const t = useTranslations()
+  const [event, setEvent] = useState<MissingTranslationEvent | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    return onMissingTranslation((ev) => {
+      setEvent(ev)
+    })
+  }, [])
+
+  if (!event) return null
+
+  const issueTitle = encodeURIComponent(`[Game i18n Missing] ${event.key} (${event.locale})`)
+  const issueBody = encodeURIComponent(
+    [
+      `### Missing Game i18n Key`,
+      `- **Key**: \`${event.key}\``,
+      `- **Locale**: \`${event.locale}\``,
+      `- **Category**: \`${event.category ?? 'unknown'}\``,
+      `- **Page**: \`${typeof window !== 'undefined' ? window.location.href : ''}\``,
+      `- **User Agent**: \`${typeof navigator !== 'undefined' ? navigator.userAgent : ''}\``,
+    ].join('\n')
+  )
+  const issueUrl = `https://github.com/cmyyx/cep/issues/new?title=${issueTitle}&body=${issueBody}`
+
+  const handleCopy = async () => {
+    const info = JSON.stringify(
+      {
+        key: event.key,
+        locale: event.locale,
+        category: event.category,
+        url: window.location.href,
+        userAgent: navigator.userAgent,
+      },
+      null,
+      2
+    )
+    try {
+      await navigator.clipboard.writeText(info)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard write failed
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'fixed bottom-6 left-6 z-[60] max-w-sm rounded-lg bg-popover p-4 text-popover-foreground shadow-[var(--shadow-card)] border border-border animate-toast-in',
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="size-5 shrink-0 text-amber-500 mt-0.5" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2 mb-1">
+            <h5 className="text-xs font-semibold leading-none">
+              {t('common.missingTranslationTitle')}
+            </h5>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-5 -mr-1 -mt-1 text-muted-foreground hover:text-foreground"
+              onClick={() => setEvent(null)}
+              aria-label={t('common.close')}
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground break-all mb-3 leading-relaxed">
+            {t('common.missingTranslationDesc', { key: event.key })}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={handleCopy}
+              className="gap-1 text-[11px]"
+            >
+              <Copy className="size-3" />
+              {copied ? t('common.reportCopied') : t('common.copyReportInfo')}
+            </Button>
+            <a
+              href={issueUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(buttonVariants({ variant: 'default', size: 'xs' }), 'gap-1 text-[11px]')}
+            >
+              <ExternalLink className="size-3" />
+              {t('common.reportToGithub')}
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/shared/missing-translation-notifier.tsx
+++ b/src/components/shared/missing-translation-notifier.tsx
@@ -23,6 +23,11 @@ export function MissingTranslationNotifier() {
 
   if (!event) return null
 
+  const pageUrl =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}${window.location.pathname}`
+      : ''
+
   const issueTitle = encodeURIComponent(`[Game i18n Missing] ${event.key} (${event.locale})`)
   const issueBody = encodeURIComponent(
     [
@@ -30,7 +35,7 @@ export function MissingTranslationNotifier() {
       `- **Key**: \`${event.key}\``,
       `- **Locale**: \`${event.locale}\``,
       `- **Category**: \`${event.category ?? 'unknown'}\``,
-      `- **Page**: \`${typeof window !== 'undefined' ? window.location.href : ''}\``,
+      `- **Page**: \`${pageUrl}\``,
       `- **User Agent**: \`${typeof navigator !== 'undefined' ? navigator.userAgent : ''}\``,
     ].join('\n')
   )
@@ -42,8 +47,8 @@ export function MissingTranslationNotifier() {
         key: event.key,
         locale: event.locale,
         category: event.category,
-        url: window.location.href,
-        userAgent: navigator.userAgent,
+        url: pageUrl,
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
       },
       null,
       2

--- a/src/components/shared/wiki-material-list.test.tsx
+++ b/src/components/shared/wiki-material-list.test.tsx
@@ -56,3 +56,16 @@ it('supports compact icon and count only rendering', () => {
   expect(screen.getByText('×12')).toBeTruthy()
   expect(screen.getByTitle('测试材料')).toBeTruthy()
 })
+
+it('resolves localized name via useWikiTranslations when name is omitted and no catalog provider is present', () => {
+  render(
+    <NextIntlClientProvider locale="zh-CN" messages={{}} timeZone="UTC">
+      <WikiMaterialList materials={[
+        { itemId: 'material-a', iconId: 'material-a', rarity: 4, count: 5 },
+      ]} />
+    </NextIntlClientProvider>,
+  )
+
+  expect(screen.getByText('测试材料')).toBeTruthy()
+  expect(screen.getByText('×5')).toBeTruthy()
+})

--- a/src/components/shared/wiki-material-list.tsx
+++ b/src/components/shared/wiki-material-list.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 import { withImageCacheVersion } from '@/lib/image-url'
 import { RarityFrame } from '@/components/shared/rarity-frame'
 import { useWikiTranslations } from '@/hooks/use-wiki-translations'
-import { useExpandedWikiMaterials } from '@/components/wiki/wiki-material-catalog'
+import { useExpandedWikiMaterials, useWikiMaterialCatalog } from '@/components/wiki/wiki-material-catalog'
 import { localizeText } from '@/lib/wiki-locale-detail'
 import { useLocale } from 'next-intl'
 import type { LocalizedText } from '@/types/wiki'
@@ -32,16 +32,21 @@ export interface WikiMaterialListProps {
 export function WikiMaterialList({ materials, compact = false, iconOnly = false, className }: WikiMaterialListProps) {
   const locale = useLocale()
   const { itemName } = useWikiTranslations()
+  const catalog = useWikiMaterialCatalog()
+  const hasCatalog = Object.keys(catalog).length > 0
   // Expand compact {itemId,count} refs when a page-level material catalog is present.
   const expanded = useExpandedWikiMaterials(materials)
-  const rows = materials.some((m) => m.iconId == null || m.rarity == null || m.name == null) ? expanded : materials
+  const rows =
+    hasCatalog && materials.some((m) => m.iconId == null || m.rarity == null || m.name == null)
+      ? expanded
+      : materials
 
   return (
     <div className={cn('flex min-w-0 flex-wrap gap-3', className)}>
       {rows.map((material) => {
-        const name = material.name
-          ? localizeText(material.name, locale)
-          : itemName(material.itemId)
+        const rawName =
+          material.name && material.name !== material.itemId ? material.name : undefined
+        const name = rawName ? localizeText(rawName, locale) : itemName(material.itemId)
         const iconId = material.iconId ?? material.itemId
         const rarity = material.rarity ?? 1
         return (

--- a/src/hooks/use-wiki-translations.ts
+++ b/src/hooks/use-wiki-translations.ts
@@ -6,6 +6,7 @@ import { useGameI18nLocale } from '@/hooks/use-game-i18n-catalogs'
 import { asWikiLocale } from '@/lib/wiki-locale'
 import { wikiTextKey } from '@/lib/wiki-i18n'
 import { entityDisplayName } from '@/lib/wiki-summary-locale'
+import { reportMissingTranslation } from '@/lib/missing-translation-guard'
 import type { WikiEntitySummary, WikiEnumGroup } from '@/types/wiki'
 
 /**
@@ -27,18 +28,32 @@ export function useWikiTranslations() {
       if (embedded && embedded !== entity.id) return embedded
     }
     if (entity.category === 'characters') {
-      return catalogs?.characters[entity.id] ?? entity.id
+      const val = catalogs?.characters[entity.id]
+      if (val != null) return val
+      if (catalogs != null) reportMissingTranslation({ key: `characters|${entity.id}`, locale, category: 'characters' })
+      return entity.id
     }
     if (entity.category === 'weapons') {
-      return catalogs?.weapons[entity.id] ?? entity.id
+      const val = catalogs?.weapons[entity.id]
+      if (val != null) return val
+      if (catalogs != null) reportMissingTranslation({ key: `weapons|${entity.id}`, locale, category: 'weapons' })
+      return entity.id
     }
-    return catalogs?.equips[entity.id] ?? entity.id
+    const val = catalogs?.equips[entity.id]
+    if (val != null) return val
+    if (catalogs != null) reportMissingTranslation({ key: `equips|${entity.id}`, locale, category: 'equips' })
+    return entity.id
   }, [catalogs, locale])
 
   const text = useCallback((...segments: Array<string | number>): string => {
     const key = wikiTextKey(...segments)
-    return catalogs?.wikiData[key] ?? String(segments.at(-1) ?? key)
-  }, [catalogs])
+    const val = catalogs?.wikiData[key]
+    if (val != null) return val
+    if (catalogs != null) {
+      reportMissingTranslation({ key, locale, category: String(segments[0] ?? '') })
+    }
+    return String(segments.at(-1) ?? key)
+  }, [catalogs, locale])
 
   const enumLabel = useCallback(
     (group: WikiEnumGroup, id: string) => text('enum', group, id),

--- a/src/lib/missing-translation-guard.ts
+++ b/src/lib/missing-translation-guard.ts
@@ -1,0 +1,78 @@
+/**
+ * Runtime guard for missing game catalog translations.
+ * Deduplicates notifications within a browser session and notifies listeners / Sentry.
+ */
+import * as Sentry from '@sentry/react'
+
+export interface MissingTranslationEvent {
+  key: string
+  locale: string
+  category?: string
+  timestamp: number
+}
+
+type MissingTranslationListener = (event: MissingTranslationEvent) => void
+
+const reportedKeys = new Set<string>()
+const listeners = new Set<MissingTranslationListener>()
+
+export function reportMissingTranslation({
+  key,
+  locale,
+  category,
+}: {
+  key: string
+  locale: string
+  category?: string
+}): void {
+  if (typeof window === 'undefined') return
+  const sessionKey = `${locale}:${key}`
+  if (reportedKeys.has(sessionKey)) return
+  reportedKeys.add(sessionKey)
+
+  const event: MissingTranslationEvent = {
+    key,
+    locale,
+    category,
+    timestamp: Date.now(),
+  }
+
+  // Report to Sentry if initialized
+  try {
+    Sentry.captureMessage(`[Game i18n Missing] key: "${key}" in locale: "${locale}"`, {
+      level: 'warning',
+      tags: {
+        i18nLocale: locale,
+        i18nKey: key,
+        i18nCategory: category ?? 'unknown',
+      },
+      extra: {
+        pathname: window.location.pathname,
+        href: window.location.href,
+      },
+    })
+  } catch {
+    // Ignore if Sentry is not available
+  }
+
+  // Notify UI subscribers
+  for (const listener of listeners) {
+    try {
+      listener(event)
+    } catch {
+      // Ignore listener errors
+    }
+  }
+}
+
+export function onMissingTranslation(listener: MissingTranslationListener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function resetMissingTranslationsForTests(): void {
+  reportedKeys.clear()
+  listeners.clear()
+}

--- a/src/lib/missing-translation-guard.ts
+++ b/src/lib/missing-translation-guard.ts
@@ -16,6 +16,8 @@ type MissingTranslationListener = (event: MissingTranslationEvent) => void
 const reportedKeys = new Set<string>()
 const listeners = new Set<MissingTranslationListener>()
 
+let bufferedEvent: MissingTranslationEvent | null = null
+
 export function reportMissingTranslation({
   key,
   locale,
@@ -48,25 +50,47 @@ export function reportMissingTranslation({
       },
       extra: {
         pathname: window.location.pathname,
-        href: window.location.href,
       },
     })
   } catch {
     // Ignore if Sentry is not available
   }
 
-  // Notify UI subscribers
-  for (const listener of listeners) {
-    try {
-      listener(event)
-    } catch {
-      // Ignore listener errors
-    }
+  // If no listeners are registered yet, buffer the latest event for replay when a listener mounts
+  if (listeners.size === 0) {
+    bufferedEvent = event
+    return
   }
+
+  // Defer notification via microtask to avoid setState during React render phase
+  queueMicrotask(() => {
+    for (const listener of listeners) {
+      try {
+        listener(event)
+      } catch {
+        // Ignore listener errors
+      }
+    }
+  })
 }
 
 export function onMissingTranslation(listener: MissingTranslationListener): () => void {
   listeners.add(listener)
+
+  if (bufferedEvent) {
+    const replayEvent = bufferedEvent
+    bufferedEvent = null
+    queueMicrotask(() => {
+      if (listeners.has(listener)) {
+        try {
+          listener(replayEvent)
+        } catch {
+          // Ignore listener errors
+        }
+      }
+    })
+  }
+
   return () => {
     listeners.delete(listener)
   }
@@ -75,4 +99,5 @@ export function onMissingTranslation(listener: MissingTranslationListener): () =
 export function resetMissingTranslationsForTests(): void {
   reportedKeys.clear()
   listeners.clear()
+  bufferedEvent = null
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -761,7 +761,12 @@
     "retry": "Retry",
     "dataLoadFailed": "Failed to load data",
     "dataLoadFailedHint": "Check your network connection and try again",
-    "viewDetails": "View details"
+    "viewDetails": "View details",
+    "missingTranslationTitle": "Text Parsing Anomaly",
+    "missingTranslationDesc": "Parsing anomaly detected for {key}. Feedback to developers is appreciated.",
+    "copyReportInfo": "Copy Details",
+    "reportCopied": "Copied",
+    "reportToGithub": "Report Issue"
   },
   "meta": {
     "homeDescription": "Arknights: Endfield planning toolkit — essence planning & calculator, refinement planning & calculator, character guides, banner calendar and more.",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -761,7 +761,12 @@
     "retry": "再試行",
     "dataLoadFailed": "データの読み込みに失敗しました",
     "dataLoadFailedHint": "ネットワーク接続を確認してから再試行してください",
-    "viewDetails": "詳細を見る"
+    "viewDetails": "詳細を見る",
+    "missingTranslationTitle": "異常テキストの検出",
+    "missingTranslationDesc": "{key} の解析異常が検出されました。開発者へのフィードバックにご協力ください。",
+    "copyReportInfo": "詳細をコピー",
+    "reportCopied": "コピーしました",
+    "reportToGithub": "問題を報告"
   },
   "meta": {
     "homeDescription": "アークナイツ：エンドフィールドの計画ツールキット——基質計画と計算、精鍛計画と計算、キャラ攻略、ガチャカレンダーなどを一括サポート。",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -544,7 +544,12 @@
     "retry": "重试",
     "dataLoadFailed": "数据加载失败",
     "dataLoadFailedHint": "请检查网络连接后重试",
-    "viewDetails": "查看详情"
+    "viewDetails": "查看详情",
+    "missingTranslationTitle": "发现异常文本",
+    "missingTranslationDesc": "检测到 {key} 解析异常，欢迎向开发者反馈。",
+    "copyReportInfo": "复制反馈信息",
+    "reportCopied": "已复制",
+    "reportToGithub": "提交反馈"
   },
   "account": {
     "title": "我的",

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -761,7 +761,12 @@
     "retry": "重試",
     "dataLoadFailed": "資料載入失敗",
     "dataLoadFailedHint": "請檢查網路連線後重試",
-    "viewDetails": "檢視詳情"
+    "viewDetails": "查看詳情",
+    "missingTranslationTitle": "發現異常文字",
+    "missingTranslationDesc": "檢測到 {key} 解析異常，歡迎向開發者回饋。",
+    "copyReportInfo": "複製回饋資訊",
+    "reportCopied": "已複製",
+    "reportToGithub": "提交回饋"
   },
   "meta": {
     "homeDescription": "《明日方舟：終末地》規劃工具集——基質規劃與計算、精鍛規劃與計算、幹員攻略、卡池日曆等一站式解決方案。",


### PR DESCRIPTION
在运行时检测到i18n异常时现在会主动发出通知提醒

## Sourcery 摘要

改进规划器材料选择和本地化可靠性，同时向用户和监控系统展示缺失的游戏翻译。

新功能：
- 检测到缺失的游戏翻译时通知用户，并提供复制诊断详情或提交 GitHub issue 的选项。
- 添加验证，确保所有规划器材料项在每个受支持的游戏语言目录中都有对应条目。

错误修复：
- 在精炼视图中，使用最新的折扣制作配方，或适当的备用配方，作为默认材料显示。
- 当材料名称缺失或仅包含物品标识符时，通过本地化目录解析材料名称。

改进：
- 通过按新近程度对配方排序，并显示配方、默认值和折扣元数据，改进制作配方的展示。

测试：
- 增加对最新配方选择、运行时缺失翻译通知以及本地化材料名称备用逻辑的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

改进规划器材料选择和游戏本地化的可靠性。

新功能：
- 当游戏本地化条目缺失时，通知用户和监控系统，并提供复制诊断信息或提交 GitHub issue 的选项。

错误修复：
- 为默认精炼材料使用最新的折扣制作配方，并提供适当的回退方案。
- 当材料名称缺失或仅包含物品标识符时，从本地化目录中解析材料名称。

增强功能：
- 通过按配方的新旧程度排序，并显示默认和折扣元数据，改进制作配方的呈现方式。

构建：
- 添加完整性检查，确保所有受支持的游戏语言目录中都存在规划器材料条目。

测试：
- 增加对最新配方选择、缺失翻译通知以及本地化材料名称回退方案的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve planner material selection and game localization reliability.

New Features:
- Notify users and monitoring systems when game localization entries are missing, with options to copy diagnostics or submit a GitHub issue.

Bug Fixes:
- Use the newest discounted crafting recipe, with appropriate fallbacks, for default refinement materials.
- Resolve material names from localized catalogs when names are missing or contain only item identifiers.

Enhancements:
- Improve crafting recipe presentation by ordering recipes by recency and showing default and discount metadata.

Build:
- Add integrity checks ensuring planner material entries exist across all supported game-language catalogs.

Tests:
- Add coverage for latest recipe selection, missing-translation notifications, and localized material-name fallbacks.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增缺失翻译提示：检测到异常文本时显示提醒，可复制详情或提交反馈。
  - 配方信息新增编号、默认及折扣标识，并优化主配方与备选配方展示。
- **问题修复**
  - 优先选择最新制作配方，提升装备推荐和精炼面板中的配方准确性。
  - 材料缺少名称等信息时，自动使用本地化目录数据补全。
  - 加强多语言内容完整性检查，减少游戏目录缺失翻译的情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->